### PR TITLE
Enable RNA multiple record update

### DIFF
--- a/amplify/backend/function/expressLambdaNpod/src/app.js
+++ b/amplify/backend/function/expressLambdaNpod/src/app.js
@@ -34,6 +34,7 @@ var {
   get_one_HLA_all_column_values,
   create_HLA,
   check_RNA_exist,
+  get_all_RNA_id,
   get_one_RNA_all_column_values,
   create_RNA,
 } = require("./service/createDatabase");
@@ -278,13 +279,24 @@ app.post("/db/check_RNA_exist", function (req, res) {
   );
 });
 
+// get all RNA_id by one case_id
+app.post("/db/get_all_RNA_id", function (req, res) {
+  console.log("Getting all RNA_id...");
+  console.log(req.body);
+  get_all_RNA_id(req.body["case_id"]).then((promisedRes) =>
+    res.send(promisedRes)
+  );
+});
+
 // get one RNA all column values
 app.post("/db/get_one_RNA_all_column_values", function (req, res) {
   console.log("Getting RNA object case.");
   console.log(req.body);
-  get_one_RNA_all_column_values(req.body["case_id"], req.body["columns"]).then(
-    (promisedRes) => res.send(promisedRes)
-  );
+  get_one_RNA_all_column_values(
+    req.body["case_id"],
+    req.body["RNA_id"],
+    req.body["columns"]
+  ).then((promisedRes) => res.send(promisedRes));
 });
 
 // create a new RNA

--- a/amplify/backend/function/expressLambdaNpod/src/service/createDatabase.js
+++ b/amplify/backend/function/expressLambdaNpod/src/service/createDatabase.js
@@ -250,7 +250,9 @@ async function get_all_AAb_id(case_id) {
         if (error) {
           reject(error);
         } else {
-          console.log(`[Fetch AAb] case ${case_id} was fetched.`);
+          console.log(
+            `[Fetch AAb] Fetching all AAb_id of the case ${case_id} was fetched.`
+          );
           resolve(result);
         }
       });
@@ -435,8 +437,30 @@ async function check_RNA_exist(case_id) {
   return await pooledConnection(asyncAction);
 }
 
+// get all RNA_id by one case_id (multiple RNA records scenario)
+async function get_all_RNA_id(case_id) {
+  console.log("Getting all RNA_id of the case " + case_id);
+  const sql = `SELECT RNA_id FROM RNA WHERE case_id='${case_id}'`;
+  console.log("sql", sql);
+  const asyncAction = async (newConnection) => {
+    return await new Promise((resolve, reject) => {
+      newConnection.query(sql, (error, result) => {
+        if (error) {
+          reject(error);
+        } else {
+          console.log(
+            `[Fetch RNA] Fetching all RNA_id of the case ${case_id} was fetched.`
+          );
+          resolve(result);
+        }
+      });
+    });
+  };
+  return await pooledConnection(asyncAction);
+}
+
 // Get one RNA row all columns values
-async function get_one_RNA_all_column_values(case_id, columns) {
+async function get_one_RNA_all_column_values(case_id, RNA_id, columns) {
   let columnStr = "";
   for (let i = 0; i < columns.length; i++) {
     if (i === 0) {
@@ -446,7 +470,7 @@ async function get_one_RNA_all_column_values(case_id, columns) {
     }
   }
   //console.log(columnStr);
-  const sql = `SELECT ${columnStr} FROM RNA WHERE case_id='${case_id}'`;
+  const sql = `SELECT ${columnStr} FROM RNA WHERE case_id='${case_id}' AND RNA_id='${RNA_id}'`;
   console.log("sql: " + sql);
   const asyncAction = async (newConnection) => {
     return await new Promise((resolve, reject) => {
@@ -455,7 +479,7 @@ async function get_one_RNA_all_column_values(case_id, columns) {
           reject(error);
         } else {
           console.log(
-            `[Fetch AAb columns] Case ${case_id} column ${columnStr} was fetched.`
+            `[Fetch RNA columns] RNA ${RNA_id} Case ${case_id} column ${columnStr} was fetched.`
           );
           resolve(result);
         }
@@ -522,6 +546,7 @@ module.exports = {
   get_one_HLA_all_column_values: get_one_HLA_all_column_values,
   create_HLA: create_HLA,
   check_RNA_exist: check_RNA_exist,
+  get_all_RNA_id: get_all_RNA_id,
   get_one_RNA_all_column_values: get_one_RNA_all_column_values,
   create_RNA: create_RNA,
 };

--- a/amplify/backend/function/expressLambdaNpod/src/service/updateDatabase.js
+++ b/amplify/backend/function/expressLambdaNpod/src/service/updateDatabase.js
@@ -159,7 +159,7 @@ async function update_RNA(columns) {
       updateStr += "," + key + "=" + columns[key];
     }
   }
-  const sql = `UPDATE RNA SET ${updateStr} WHERE case_id=${columns.case_id}`;
+  const sql = `UPDATE RNA SET ${updateStr} WHERE case_id=${columns.case_id} AND RNA_id=${columns.RNA_id}`;
   console.log("sql: ", sql);
   const asyncAction = async (newConnection) => {
     return await new Promise((resolve, reject) => {

--- a/amplify/team-provider-info.json
+++ b/amplify/team-provider-info.json
@@ -15,7 +15,7 @@
       "function": {
         "expressLambdaNpod": {
           "deploymentBucketName": "amplify-amplifynpod-dev-163022-deployment",
-          "s3Key": "amplify-builds/expressLambdaNpod-74456e7436486a707a59-build.zip"
+          "s3Key": "amplify-builds/expressLambdaNpod-51575a42716f4858657a-build.zip"
         }
       },
       "auth": {

--- a/src/component/Admin/Admin.js
+++ b/src/component/Admin/Admin.js
@@ -516,7 +516,7 @@ export default function Admin() {
                       {/* RNA Create */}
                       {activeStep === 8 ? (
                         <Button
-                          disabled={RNAExist === true || caseId === ""}
+                          disabled={caseId === ""}
                           onClick={handleCreateRNA}
                           className={classes.button}
                           variant="contained"

--- a/src/component/Admin/component/AAB_step6.js
+++ b/src/component/Admin/component/AAB_step6.js
@@ -4,7 +4,7 @@ import GridBox from "./component/GridBox";
 import DropBox from "./component/DropBox";
 import useDebounced from "./component/useDebounced";
 import useCheckAAbExist from "./component/useCheckAAbExist";
-import useRetrieveAAbId from "./component/useRetrieveAllAAbId";
+import useRetrieveAllAAbIds from "./component/useRetrieveAllAAbIds";
 import useRetrieveAAbColumns from "./component/useRetrieveAAbColumns";
 import useUpdateAAb from "./component/useUpdateAAb";
 import useCreateAAb from "./component/useCreateAAb";
@@ -162,21 +162,16 @@ export default function AAb_step6({
     setAAbExistMsg
   );
 
-  const AAbIdList = useRetrieveAAbId(caseId);
+  const AAbIdList = useRetrieveAllAAbIds(caseId);
   const AAbIdOps = AAbIdOpsGenerator(AAbIdList, AAbIdList);
   const AAbIdListName = "AAb ID List";
   const [AAbIdValue, setAAbIdValue] = useState(AAbIdList[0]);
 
   const defaultValue = useRetrieveAAbColumns(caseId, AAbIdValue, columnList);
   useEffect(() => {
-    setValue0(defaultValue[0]);
-    setValue1(defaultValue[1]);
-    setValue2(defaultValue[2]);
-    setValue3(defaultValue[3]);
-    setValue4(defaultValue[4]);
-    setValue5(defaultValue[5]);
-    setValue6(defaultValue[6]);
-    setValue7(defaultValue[7]);
+    for (let i = 0; i < setValueList.length; i++) {
+      setValueList[i](defaultValue[i]);
+    }
   }, [defaultValue]);
 
   const [value0, setValue0] = useDebounced(defaultValue[0], 800);

--- a/src/component/Admin/component/component/useCreateRNA.js
+++ b/src/component/Admin/component/component/useCreateRNA.js
@@ -3,6 +3,7 @@ import { API, Auth } from "aws-amplify";
 
 export default function useCreateRNA(
   caseId,
+  RNAIdValue,
   isExist,
   create,
   changed,
@@ -15,13 +16,17 @@ export default function useCreateRNA(
 ) {
   const [result, setResult] = useState(false);
   useEffect(() => {
-    if (!isExist && create && !changed) {
+    if (create && !changed && RNAIdValue === "New") {
       createRNA(caseId, columnList, valueList);
       console.log("New RNA has been created!");
       console.log("column list", columnList);
       console.log("value list", valueList);
     } else {
       console.log("RNA create condition is not met.");
+      if (create) {
+        setCreateSuccess(false);
+        setCreateMsg(`RNA case ${caseId} create is failed.`);
+      }
     }
   }, [caseId, isExist, create, changed]);
 

--- a/src/component/Admin/component/component/useRetrieveAllAAbIds.js
+++ b/src/component/Admin/component/component/useRetrieveAllAAbIds.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { API, Auth } from "aws-amplify";
 
-export default function useRetrieveAllAAbId(caseId) {
+export default function useRetrieveAllAAbIds(caseId) {
   const [result, setResult] = useState([]);
   useEffect(() => {
     if (caseId !== "") {

--- a/src/component/Admin/component/component/useRetrieveAllRNAIds.js
+++ b/src/component/Admin/component/component/useRetrieveAllRNAIds.js
@@ -1,0 +1,29 @@
+import React, { useState, useEffect } from "react";
+import { API, Auth } from "aws-amplify";
+
+export default function useRetrieveAllRNAIds(caseId) {
+  const [result, setResult] = useState([]);
+  useEffect(() => {
+    if (caseId !== "") {
+      getRNAId(caseId);
+    }
+  }, [caseId]);
+
+  async function getRNAId(id) {
+    return await API.post("dbapi", "/db/get_all_RNA_id", {
+      body: {
+        case_id: id,
+      },
+    })
+      .then((res) => {
+        console.log("RNA id list fetch result", res);
+        for (let i = 0; i < res.length; i++) {
+          setResult((oldResult) => [...oldResult, res[i]["RNA_id"]]);
+        }
+      })
+      .catch((error) => {
+        console.log("[RNA] Amplify API call error", error);
+      });
+  }
+  return result;
+}

--- a/src/component/Admin/component/component/useRetrieveRNAColumns.js
+++ b/src/component/Admin/component/component/useRetrieveRNAColumns.js
@@ -1,20 +1,21 @@
 import React, { useState, useEffect } from "react";
 import { API, Auth } from "aws-amplify";
 
-export default function useRetrieveRNAColumns(caseId, columnList) {
+export default function useRetrieveRNAColumns(caseId, RNAIdValue, columnList) {
   const [result, setResult] = useState(Array(columnList.length).fill(null));
   useEffect(() => {
     if (caseId !== "") {
       console.log("[RNA] Retrieving column values condition met.");
-      retrieve(caseId, columnList);
+      retrieve(caseId, RNAIdValue, columnList);
     } else {
       console.log("Retreive RNA condition not met.");
     }
-  }, [caseId]);
-  async function retrieve(id, columns) {
+  }, [caseId, RNAIdValue]);
+  async function retrieve(the_case_id, the_RNA_id, columns) {
     return await API.post("dbapi", "/db/get_one_RNA_all_column_values", {
       body: {
-        case_id: id,
+        case_id: the_case_id,
+        RNA_id: the_RNA_id,
         columns: columns,
       },
     })
@@ -29,7 +30,8 @@ export default function useRetrieveRNAColumns(caseId, columnList) {
       })
       .catch((error) => {
         console.log("[RNA Retrieve] Retrieve case columns failed.");
-        console.log("[RNA Retrieve] Failed case id", id);
+        console.log("[RNA Retrieve] Failed case id", the_case_id);
+        console.log("[AAb] Failed RNA id", the_RNA_id);
         console.log("[RNA Retrieve] Failed columnList", columns);
         console.log("[RNA Retrieve] Amplify API call error", error);
       });

--- a/src/component/Admin/component/component/useUpdateRNA.js
+++ b/src/component/Admin/component/component/useUpdateRNA.js
@@ -3,6 +3,7 @@ import { API, Auth } from "aws-amplify";
 
 export default function useUpdateRNA(
   caseId,
+  RNAIdValue,
   update,
   changed,
   setAccept,
@@ -14,13 +15,17 @@ export default function useUpdateRNA(
 ) {
   const [result, setResult] = useState(false);
   useEffect(() => {
-    if (update && !changed) {
+    if (update && !changed && RNAIdValue !== "New") {
       console.log("[RNA] Updating case columns...");
-      updateRNA(caseId, updateColumns, updateValues);
+      updateRNA(caseId, RNAIdValue, updateColumns, updateValues);
+    } else if (update) {
+      setShowUpdateError(true);
+      setShowUpdateSuccess(false);
+      setUpdateMsg("[RNA] Update is failed.");
     }
   }, [caseId, update, changed]);
-  async function updateRNA(id, columnNames, columnValues) {
-    let columns = { case_id: id };
+  async function updateRNA(the_case_id, the_RNA_id, columnNames, columnValues) {
+    let columns = { case_id: the_case_id, RNA_id: the_RNA_id };
     for (let i = 0; i < columnNames.length; i++) {
       columns[columnNames[i]] = columnValues[i];
     }
@@ -32,8 +37,10 @@ export default function useUpdateRNA(
     })
       .then((res) => {
         if (res["affectedRows"] ?? false) {
-          console.log("[RNA] Update success id", id);
-          console.log("[RNA] Update success columns", columns);
+          console.log("[RNA] Update success Case ID", the_case_id);
+          console.log("[RNA] Update success RNA ID", the_RNA_id);
+          console.log("[RNA] Update success columns", columnNames);
+          console.log("[RNA] Update success values", columnValues);
           setResult(true);
           setShowUpdateError(false);
           setShowUpdateSuccess(true);
@@ -47,8 +54,10 @@ export default function useUpdateRNA(
         setShowUpdateSuccess(false);
         setUpdateMsg("[RNA] Update is failed");
         console.log("[RNA Update] Amplify API call error", error);
-        console.log("[RNA Update] Fail case id", id);
-        console.log("[RNA Update] Fail columns", columns);
+        console.log("[RNA] Update fail case ID", the_case_id);
+        console.log("[RNA] Update fail AAb ID", the_RNA_id);
+        console.log("[RNA] Update fail columns", columnNames);
+        console.log("[RNA] Update fail values", columnValues);
       });
   }
 


### PR DESCRIPTION
Since RNA table has multiple records having same case_id, this update add RNA ID List dropdown menu for picking desire RNA_id record.
Creating a new RNA record no longer restricted by absense case_id in RNA table.