### PR TITLE
fix support 'location' and markdown

### DIFF
--- a/src/component/Support/Support.js
+++ b/src/component/Support/Support.js
@@ -8,6 +8,7 @@ import Container from "@material-ui/core/Container";
 import AuthHeader from "..//AuthHeader";
 import { Paper } from "@material-ui/core";
 import Markdown from "./Markdown";
+import ReactMarkdown from "markdown-to-jsx";
 
 // TODO: Remember me function need further implementation.
 // For now, Cognito will let user opt in remembering device.
@@ -86,13 +87,13 @@ function Support(props) {
 
   return (
     <div>
-      <AuthHeader location="Sign In" />
+      <AuthHeader location="Support" />
       <Container Width="md" maxWidth="lg" className={classes.container}>
         <Typography variant="h3" className={classes.title}>
           SUPPORT
         </Typography>
         <Paper className={classes.paper}>
-          <Markdown className={classes.markDown}>{post}</Markdown>
+          <ReactMarkdown className={classes.markDown}>{post}</ReactMarkdown>
         </Paper>
         <Box mt={8} className={classes.copyRight}>
           <Copyright />

--- a/src/route/Contact.js
+++ b/src/route/Contact.js
@@ -73,7 +73,7 @@ function Contact(props) {
   const classes = useStyles();
   return (
     <div>
-      <AuthHeader location="Sign In" />
+      <AuthHeader location="Contact" />
       <Container component="main" maxWidth="md">
         <CssBaseline />
         <Paper className={classes.paper}>


### PR DESCRIPTION
support and contact used 'signin' as locatiion and it got fixed.
replace self defined markdown component with markdown-to-jsx.
current issue is aws amplify can't correctly show rendered html.