### PR TITLE
Add amplify backend lambda function to VPC

### DIFF
--- a/amplify/backend/function/expressLambdaNpod/expressLambdaNpod-cloudformation-template.json
+++ b/amplify/backend/function/expressLambdaNpod/expressLambdaNpod-cloudformation-template.json
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"Amplify\",\"createdWith\":\"7.5.5\",\"stackType\":\"function-Lambda\",\"metadata\":{}}",
+  "Description": "{\"createdOn\":\"Mac\",\"createdBy\":\"Amplify\",\"createdWith\":\"7.6.9\",\"stackType\":\"function-Lambda\",\"metadata\":{}}",
   "Parameters": {
     "CloudWatchRule": {
       "Type": "String",
@@ -35,6 +35,15 @@
         "aws:asset:property": "Code"
       },
       "Properties": {
+        "VpcConfig": {
+          "SubnetIds": [
+            "subnet-0b0cbb509b1c11e3c",
+            "subnet-062e529135e3b635f"
+          ],
+          "SecurityGroupIds": [
+            "sg-0702ae10b1e390917"
+          ]
+        },
         "Code": {
           "S3Bucket": {
             "Ref": "deploymentBucketName"

--- a/amplify/team-provider-info.json
+++ b/amplify/team-provider-info.json
@@ -16,7 +16,7 @@
       "function": {
         "expressLambdaNpod": {
           "deploymentBucketName": "amplify-amplifynpod-dev-163022-deployment",
-          "s3Key": "amplify-builds/expressLambdaNpod-45587355724b4366654c-build.zip"
+          "s3Key": "amplify-builds/expressLambdaNpod-56376867557a66625944-build.zip"
         }
       },
       "auth": {
@@ -42,6 +42,31 @@
         "expressLambdaNpod": {
           "deploymentBucketName": "amplify-amplifynpod-prod-132809-deployment",
           "s3Key": "amplify-builds/expressLambdaNpod-75526f504e2f4f62674e-build.zip"
+        }
+      },
+      "auth": {
+        "amplifynpod3b9354c9": {}
+      }
+    }
+  },
+  "vpctest": {
+    "awscloudformation": {
+      "AuthRoleName": "amplify-amplifynpod-vpctest-135356-authRole",
+      "UnauthRoleArn": "arn:aws:iam::762002863320:role/amplify-amplifynpod-vpctest-135356-unauthRole",
+      "AuthRoleArn": "arn:aws:iam::762002863320:role/amplify-amplifynpod-vpctest-135356-authRole",
+      "Region": "us-east-1",
+      "DeploymentBucketName": "amplify-amplifynpod-vpctest-135356-deployment",
+      "UnauthRoleName": "amplify-amplifynpod-vpctest-135356-unauthRole",
+      "StackName": "amplify-amplifynpod-vpctest-135356",
+      "StackId": "arn:aws:cloudformation:us-east-1:762002863320:stack/amplify-amplifynpod-vpctest-135356/a5f97d90-806b-11ec-b6b5-0ed84e0bd94f",
+      "AmplifyAppId": "d21vputqov8m0s",
+      "APIGatewayAuthURL": "https://s3.amazonaws.com/amplify-amplifynpod-vpctest-135356-deployment/amplify-cfn-templates/api/APIGatewayAuthStack.json"
+    },
+    "categories": {
+      "function": {
+        "expressLambdaNpod": {
+          "deploymentBucketName": "amplify-amplifynpod-vpctest-135356-deployment",
+          "s3Key": "amplify-builds/expressLambdaNpod-56376867557a66625944-build.zip"
         }
       },
       "auth": {


### PR DESCRIPTION
So the lambda function can access to RDS MySQL instance securely
through private subnet with same security group with the RDS.