### PR TITLE
Fix forgot and reset password

### DIFF
--- a/amplify/backend/function/emailFilterAuthTrigger/src/index.js
+++ b/amplify/backend/function/emailFilterAuthTrigger/src/index.js
@@ -43,7 +43,11 @@ exports.handler = (event, context, callback) => {
     var body =
       "Hi " +
       event.userName +
-      ", your sign-up on nPOD has been received and waiting for approval.";
+      ", your sign-up on nPOD has been received and waiting for approval." +
+      "\r\n" +
+      "You have agreed and understand nPOD website terms and conditions." +
+      "\r\n" +
+      "Please check: https://portal.jdrfnpod.org/useragreement for details.";
     var body2 = "\r\n" + "Sent at " + dateTime + " UTC";
     var toAdmin = "npod.aws@gmail.com";
     var subjectAdmin = "New User Sign-up on nPOD";

--- a/amplify/backend/function/postConfirmAuthTrigger/src/index.js
+++ b/amplify/backend/function/postConfirmAuthTrigger/src/index.js
@@ -20,7 +20,11 @@ exports.handler = (event, context, callback) => {
     "\r\n" +
     "Now you can login and start using the account now." +
     "\r\n" +
-    "Log in here: https://portal.jdrfnpod.org/signin";
+    "Log in here: https://portal.jdrfnpod.org/signin" +
+    "\r\n" +
+    "Please verify your email address after first time login." +
+    "\r\n" +
+    "Verify your email: https://portal.jdrfnpod.org/verifyemail";
   var body2 = "\r\n" + "Sent at " + dateTime + " UTC";
   if (event.request.userAttributes.email) {
     sendEmail(to, subject, body + " " + body2, function (status) {

--- a/amplify/team-provider-info.json
+++ b/amplify/team-provider-info.json
@@ -24,11 +24,11 @@
         },
         "emailFilterAuthTrigger": {
           "deploymentBucketName": "amplify-amplifynpod-dev-163022-deployment",
-          "s3Key": "amplify-builds/emailFilterAuthTrigger-5a4d6638526764396a4c-build.zip"
+          "s3Key": "amplify-builds/emailFilterAuthTrigger-424a516d544e61354266-build.zip"
         },
         "postConfirmAuthTrigger": {
           "deploymentBucketName": "amplify-amplifynpod-dev-163022-deployment",
-          "s3Key": "amplify-builds/postConfirmAuthTrigger-4c6c594a566954442f57-build.zip"
+          "s3Key": "amplify-builds/postConfirmAuthTrigger-73316c466c4f79723469-build.zip"
         }
       },
       "auth": {

--- a/src/App.js
+++ b/src/App.js
@@ -22,6 +22,8 @@ import SupportPage from "./route/SupportPage";
 import Contact from "./route/Contact";
 import VerifyEmail from "./route/VerifyEmail";
 import VerifyAttributeWithCode from "./route/VerifyAttributeWithCode";
+import UserAgreementPage from "./route/UserAgreementPage";
+import ResetPassword from "./route/ResetPassword";
 
 Amplify.configure({
   ...config,
@@ -77,6 +79,8 @@ function App(props) {
       <Route path="/support" component={SupportPage} />
       <Route path="/contact" component={Contact} />
       <Route path="/verify" component={VerifyAttributeWithCode} />
+      <Route path="/useragreement" component={UserAgreementPage} />
+      <Route path="/resetpassword" component={ResetPassword} />
     </Router>
   );
 }

--- a/src/component/Admin/component/UserManage/UserManage.js
+++ b/src/component/Admin/component/UserManage/UserManage.js
@@ -108,8 +108,7 @@ export default function WriteIn() {
   const [confirmClicked, setConfirmClicked] = useState(0);
 
   useEffect(() => {
-    let nextToken;
-    async function listUsers(limit) {
+    async function listUsers(limit, nextToken, allUsers = []) {
       let apiName = "AdminQueries";
       let path = "/listUsers";
       let myInit = {
@@ -125,14 +124,20 @@ export default function WriteIn() {
         },
       };
       const { NextToken, ...rest } = await API.get(apiName, path, myInit);
+      allUsers.push(rest);
       nextToken = NextToken;
-      return rest;
+      // recursion to exhausting all users
+      if (nextToken) {
+        return listUsers(limit, nextToken, allUsers);
+      } else {
+        return allUsers;
+      }
     }
-    listUsers(59)
+    listUsers(null, null)
       .then((res) => {
         console.log("list all users: sucess");
-        setUserData(res.Users);
-        setUserRows(createRows(res.Users));
+        setUserData(res[0].Users);
+        setUserRows(createRows(res[0].Users));
       })
       .catch((err) => console.error("list all users error: ", err));
   }, []);

--- a/src/component/UserAgreement/UserAgreement.js
+++ b/src/component/UserAgreement/UserAgreement.js
@@ -1,0 +1,125 @@
+import React, { useEffect, useState } from "react";
+import CssBaseline from "@material-ui/core/CssBaseline";
+import Link from "@material-ui/core/Link";
+import Box from "@material-ui/core/Box";
+import Typography from "@material-ui/core/Typography";
+import { makeStyles } from "@material-ui/core/styles";
+import Container from "@material-ui/core/Container";
+import AuthHeader from "..//AuthHeader";
+import { Paper } from "@material-ui/core";
+import ReactMarkdown from "react-markdown";
+
+// TODO: Remember me function need further implementation.
+// For now, Cognito will let user opt in remembering device.
+
+function Copyright() {
+  return (
+    <Typography variant="body2" color="textSecondary" align="center">
+      {"Copyright © "}
+      <Link color="inherit" href="https://nPOD.org/">
+        nPOD
+      </Link>{" "}
+      {new Date().getFullYear()}
+      {"."}
+    </Typography>
+  );
+}
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    minHeight: "100vh",
+    backgroundImage: `url(${
+      process.env.PUBLIC_URL + "/assets/supportPage.jpg"
+    })`,
+    backgroundRepeat: "no-repeat",
+    backgroundSize: "cover",
+    //textAlign: "center",
+    //backgroundColor: "#282c34",
+    //flexDirection: "column",
+    //alignItems: "center",
+    //justifyContent: "center",
+    //color: "white",
+    //paddingTop: "130px",
+  },
+  paper: {
+    marginTop: theme.spacing(15),
+    paddingTop: theme.spacing(5),
+    paddingBottom: theme.spacing(15),
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+  },
+  markDown: {
+    paddingTop: theme.spacing(3),
+    paddingBottom: theme.spacing(5),
+    paddingLeft: theme.spacing(15),
+    paddingRight: theme.spacing(15),
+  },
+  container: {
+    display: "flex",
+    flexDirection: "column",
+  },
+  title: {
+    margin: theme.spacing(5),
+    fontWeight: 600,
+    alignSelf: "center",
+    color: "white",
+  },
+  copyRight: {
+    marginBottom: "50px",
+  },
+  avatar: {
+    margin: theme.spacing(1),
+    backgroundColor: theme.palette.secondary.main,
+  },
+  form: {
+    width: "100%", // Fix IE 11 issue.
+    marginTop: theme.spacing(1),
+  },
+  submit: {
+    margin: theme.spacing(3, 0, 2),
+  },
+  alert: {
+    position: "fixed",
+    bottom: 0,
+    width: "100%",
+  },
+}));
+
+function UserAgreement(props) {
+  const classes = useStyles();
+  const [post, setPost] = useState("");
+
+  useEffect(() => {
+    const setTheText = async () => {
+      const fileName = "userAgreementText";
+      const file = await import(`./${fileName}.txt`);
+      const response = await fetch(file.default);
+      const text = await response.text();
+      setPost(text);
+    };
+    setTheText();
+  }, []);
+
+  console.log("(out of useeffect)md file content", post);
+  const test_text = "# sample title";
+  return (
+    <div>
+      <AuthHeader location="UserAgreement" />
+      <div className={classes.root}>
+        <Container Width="md" maxWidth="md" className={classes.container}>
+          <Paper className={classes.paper}>
+            <h1 align="center">USER AGREEMENT</h1>
+            <h2 align="center">FOR nPOD DATA PORTAL</h2>
+            <ReactMarkdown className={classes.markDown}>{post}</ReactMarkdown>
+          </Paper>
+          <Box mt={8} className={classes.copyRight}>
+            <Copyright />
+          </Box>
+        </Container>
+      </div>
+    </div>
+  );
+}
+
+export default UserAgreement;

--- a/src/component/UserAgreement/userAgreementText.md
+++ b/src/component/UserAgreement/userAgreementText.md
@@ -1,0 +1,10 @@
+# USER AGREEMENT
+
+## FOR nPOD DATA PORTAL
+
+The goals of the nPOD project are to recover relevant tissue from our donor groups, share these gifts with approved scientific investigators who seek to prevent, reverse and ultimately cure the disease and foster collaboration amongst these investigators. This data portal contains data on donor summary, clinical history, case processing and tissue quality, functional assay, histopathology and immunophenotyping. A variety of investigator-generated data will also be available for download in future updates.
+In order to access or download data from the nPOD data portal, users must agree to the following terms. This is in addition to required IRB approval, which must be submitted to nPOD separately prior to access. Users agree to the following terms by accessing the nPOD data portal.
+Users of the nPOD data portal will not have access to or receive any identities or personally-identifiable information of data subjects, nor any information through which their identities could be readily ascertained. Users will not use data accessed or received from the nPOD data portal alone or in conjunction with other data, in an effort to reidentify any individual. Users agree not to ask nPOD personnel for any identifiable information, and acknowledge that University personnel will not provide this information even if requested.
+Only the nPOD approved investigators are permitted to access the data portal. Login information must not be shared with others. All data obtained through the portal will only be accessed or used by authorized users, and further distribution of any data is prohibited.
+All data provided through the nPOD data portal are provided as-is and without warranty, including without limitation any warranty of quality, accuracy, fitness for a particular purpose, or warranty of non-infringement of any intellectual property rights.
+Data provided through the nPOD data portal are not intended or designed for use in medical treatment decisions, and the University of Florida and its affiliates, employees and agents will have no responsibility or liability for any injuries in any way related to such use.

--- a/src/component/UserAgreement/userAgreementText.txt
+++ b/src/component/UserAgreement/userAgreementText.txt
@@ -1,0 +1,11 @@
+The goals of the nPOD project are to recover relevant tissue from our donor groups, share these gifts with approved scientific investigators who seek to prevent, reverse and ultimately cure the disease and foster collaboration amongst these investigators. This data portal contains data on donor summary, clinical history, case processing and tissue quality, functional assay, histopathology and immunophenotyping. A variety of investigator-generated data will also be available for download in future updates.
+
+In order to access or download data from the nPOD data portal, users must agree to the following terms. This is in addition to required IRB approval, which must be submitted to nPOD separately prior to access. Users agree to the following terms by accessing the nPOD data portal.
+
+Users of the nPOD data portal will not have access to or receive any identities or personally-identifiable information of data subjects, nor any information through which their identities could be readily ascertained. Users will not use data accessed or received from the nPOD data portal alone or in conjunction with other data, in an effort to reidentify any individual. Users agree not to ask nPOD personnel for any identifiable information, and acknowledge that University personnel will not provide this information even if requested.
+
+Only the nPOD approved investigators are permitted to access the data portal. Login information must not be shared with others. All data obtained through the portal will only be accessed or used by authorized users, and further distribution of any data is prohibited.
+
+All data provided through the nPOD data portal are provided as-is and without warranty, including without limitation any warranty of quality, accuracy, fitness for a particular purpose, or warranty of non-infringement of any intellectual property rights.
+
+Data provided through the nPOD data portal are not intended or designed for use in medical treatment decisions, and the University of Florida and its affiliates, employees and agents will have no responsibility or liability for any injuries in any way related to such use.

--- a/src/route/ForgotPassword.js
+++ b/src/route/ForgotPassword.js
@@ -12,7 +12,7 @@ import LockOutlinedIcon from "@material-ui/icons/LockOutlined";
 import Typography from "@material-ui/core/Typography";
 import { makeStyles } from "@material-ui/core/styles";
 import Container from "@material-ui/core/Container";
-import Auth from "@aws-amplify/auth";
+import { Auth } from "@aws-amplify/auth";
 import { useHistory } from "react-router-dom";
 import IconButton from "@material-ui/core/IconButton";
 import InputAdornment from "@material-ui/core/InputAdornment";
@@ -21,6 +21,7 @@ import VisibilityOff from "@material-ui/icons/VisibilityOff";
 import Alert from "@material-ui/lab/Alert";
 import Fade from "@material-ui/core/Fade";
 import AuthHeader from "../component/AuthHeader";
+import AlertDialog from "../component/AlertDialog";
 
 function Copyright() {
   return (
@@ -76,6 +77,9 @@ export default function ForgotPassword() {
   const [successMsg, setSuccessMsg] = useState(null);
   const [showFail, setShowFail] = useState(false);
   const [errorMsg, setErrorMsg] = useState(null);
+  const [openAlert, setOpenAlert] = useState(false);
+  const [alertTitle, setAlertTitle] = useState("Notice");
+  const [alertContent, setAlertCotent] = useState("");
 
   const handleChange = (event) => {
     event.persist();
@@ -90,19 +94,26 @@ export default function ForgotPassword() {
     setShowNewPassword(!showNewPassword);
   };
 
-  const handleSumbitSendCode = async function (event) {
+  const handleSumbitSendVerification = async function (event) {
     event.preventDefault();
     const { username } = formState;
     try {
       const response = await Auth.forgotPassword(username);
-      console.log("SendCode response: ", response);
-      setSuccessMsg("Confirmation code was sent! Please check your email");
+      console.log("Reset password response (send verification): ", response);
+      setSuccessMsg("Verification was sent! Please check your email");
       showAlertHandler("success");
-      updateFormState(() => ({ ...formState, formType: "setNewPassword" }));
+      setAlertTitle("Reset Password Notice");
+      setAlertCotent(
+        "Verification was sent, please check the email and click the link to reset your password"
+      );
+      setOpenAlert(true);
     } catch (error) {
-      console.log("SendCode error: ", error);
+      console.log("Reset password error (send verification): ", error);
       setErrorMsg(error.message);
       showAlertHandler("fail");
+      setAlertTitle("Reset Password Error");
+      setAlertCotent("Reset password has an error: " + error.message);
+      setOpenAlert(true);
     }
   };
 
@@ -140,66 +151,82 @@ export default function ForgotPassword() {
     }
   };
 
+  const handleGoHome = () => {
+    history.push("/");
+  };
+
   return (
     <div>
       <AuthHeader location="Forgot Password" />
       {/* Send Confirmation Code */}
-      {formType === "sendCode" && (
-        <div>
-          <Container component="main" maxWidth="xs">
-            <CssBaseline />
-            <div className={classes.paper}>
-              <Avatar className={classes.avatar}>
-                <LockOutlinedIcon />
-              </Avatar>
-              <Typography component="h1" variant="h5">
-                Reset Password
-              </Typography>
-              <form
-                className={classes.form}
-                noValidate
-                onSubmit={handleSumbitSendCode}
+      <AlertDialog
+        title={alertTitle}
+        contentText={alertContent}
+        open={openAlert}
+        setOpen={setOpenAlert}
+        btn1Name="Back"
+        btn2Name="Home"
+        callBack={handleGoHome}
+      />
+      <div>
+        <Container component="main" maxWidth="xs">
+          <CssBaseline />
+          <div className={classes.paper}>
+            <Avatar className={classes.avatar}>
+              <LockOutlinedIcon />
+            </Avatar>
+            <Typography component="h1" variant="h5">
+              Reset Password
+            </Typography>
+            <form
+              className={classes.form}
+              noValidate
+              onSubmit={handleSumbitSendVerification}
+            >
+              <Grid container spacing={2}>
+                <Grid item xs={12}>
+                  <TextField
+                    variant="outlined"
+                    margin="normal"
+                    required
+                    fullWidth
+                    id="username"
+                    label="Username"
+                    name="username"
+                    autoComplete="username"
+                    autoFocus
+                    onChange={handleChange}
+                  />
+                </Grid>
+              </Grid>
+              <Button
+                type="submit"
+                fullWidth
+                variant="contained"
+                color="primary"
+                className={classes.submit}
               >
-                <Grid container spacing={2}>
-                  <Grid item xs={12}>
-                    <TextField
-                      variant="outlined"
-                      margin="normal"
-                      required
-                      fullWidth
-                      id="username"
-                      label="Username"
-                      name="username"
-                      autoComplete="username"
-                      autoFocus
-                      onChange={handleChange}
-                    />
-                  </Grid>
+                Send Verify Link
+              </Button>
+              <p className={classes.helperText}>
+                <Typography variant="caption">
+                  Click the link in your email inbox to verify your identity
+                </Typography>
+              </p>
+              <Grid container justify="flex-end">
+                <Grid item>
+                  <Link href="signin" variant="body2">
+                    Already have an account? Sign in
+                  </Link>
                 </Grid>
-                <Button
-                  type="submit"
-                  fullWidth
-                  variant="contained"
-                  color="primary"
-                  className={classes.submit}
-                >
-                  Email Confirm Code
-                </Button>
-                <Grid container justify="flex-end">
-                  <Grid item>
-                    <Link href="signin" variant="body2">
-                      Already have an account? Sign in
-                    </Link>
-                  </Grid>
-                </Grid>
-              </form>
-            </div>
-            <Box mt={5}>
-              <Copyright />
-            </Box>
-          </Container>
-        </div>
-      )}
+              </Grid>
+            </form>
+          </div>
+          <Box mt={5}>
+            <Copyright />
+          </Box>
+        </Container>
+      </div>
 
       {/* Set new password */}
       {formType === "setNewPassword" && (

--- a/src/route/ResetPassword.js
+++ b/src/route/ResetPassword.js
@@ -1,0 +1,494 @@
+import React, { useState, useEffect } from "react";
+import Avatar from "@material-ui/core/Avatar";
+import Button from "@material-ui/core/Button";
+import CssBaseline from "@material-ui/core/CssBaseline";
+import TextField from "@material-ui/core/TextField";
+import Link from "@material-ui/core/Link";
+import Grid from "@material-ui/core/Grid";
+import Box from "@material-ui/core/Box";
+import LockOutlinedIcon from "@material-ui/icons/LockOutlined";
+import Typography from "@material-ui/core/Typography";
+import { makeStyles } from "@material-ui/core/styles";
+import Container from "@material-ui/core/Container";
+import { Auth } from "@aws-amplify/auth";
+import { useHistory } from "react-router-dom";
+import IconButton from "@material-ui/core/IconButton";
+import InputAdornment from "@material-ui/core/InputAdornment";
+import Visibility from "@material-ui/icons/Visibility";
+import VisibilityOff from "@material-ui/icons/VisibilityOff";
+import Alert from "@material-ui/lab/Alert";
+import Fade from "@material-ui/core/Fade";
+import AuthHeader from "../component/AuthHeader";
+import AlertDialog from "../component/AlertDialog";
+
+function Copyright() {
+  return (
+    <Typography variant="body2" color="textSecondary" align="center">
+      {"Copyright © "}
+      <Link color="inherit" href="https://nPOD.org/">
+        nPOD
+      </Link>{" "}
+      {new Date().getFullYear()}
+      {"."}
+    </Typography>
+  );
+}
+
+const useStyles = makeStyles((theme) => ({
+  paper: {
+    marginTop: theme.spacing(8),
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+  },
+  avatar: {
+    margin: theme.spacing(1),
+    backgroundColor: theme.palette.secondary.main,
+  },
+  form: {
+    width: "100%", // Fix IE 11 issue.
+    marginTop: theme.spacing(3),
+  },
+  submit: {
+    margin: theme.spacing(3, 0, 2),
+  },
+  alert: {
+    position: "fixed",
+    bottom: 0,
+    width: "100%",
+  },
+  passwordHint: {
+    marginTop: "1px",
+  },
+  passwordGreen: {
+    color: "green",
+    paddingLeft: "20px",
+    fontSize: 12,
+  },
+  passwordRed: {
+    color: "red",
+    paddingLeft: "20px",
+    fontSize: 12,
+  },
+}));
+
+const initialFormState = {
+  username: "",
+  new_password: "",
+  re_new_password: "",
+};
+
+export default function ResetPassword(props) {
+  const classes = useStyles();
+  const history = useHistory();
+  const [formState, updateFormState] = useState(initialFormState);
+  const [showNewPassword, setShowNewPassword] = useState(false);
+  const [showReNewPassword, setShowReNewPassword] = useState(false);
+  const [showSuccess, setShowSuccess] = useState(false);
+  const [successMsg, setSuccessMsg] = useState(null);
+  const [showFail, setShowFail] = useState(false);
+  const [errorMsg, setErrorMsg] = useState(null);
+  const [met7Chars, setMet7Chars] = useState(false);
+  const [met1Upper, setMet1Upper] = useState(false);
+  const [met1Lower, setMet1Lower] = useState(false);
+  const [met1Number, setMet1Number] = useState(false);
+  const [met1Special, setMet1Special] = useState(false);
+  const [rePasswordMatch, setRePasswordMatch] = useState(false);
+  const [openAlert, setOpenAlert] = useState(false);
+  const [alertTitle, setAlertTitle] = useState("Notice");
+  const [alertContent, setAlertCotent] = useState("");
+
+  const handleSumbitSetNewPassword = async function (event) {
+    event.preventDefault();
+    const { username, new_password, re_new_password } = formState;
+    const verify_code =
+      (props.location.state && props.location.state.verify_code) || null;
+    console.log(
+      "username: " +
+        username +
+        "\r\n" +
+        "password: " +
+        new_password +
+        "\r\n" +
+        "re password: " +
+        re_new_password +
+        "\r\n" +
+        "verify code: " +
+        verify_code
+    );
+    try {
+      if (
+        username === null ||
+        username.length < 1 ||
+        new_password === null ||
+        new_password.length < 1 ||
+        re_new_password === null ||
+        re_new_password.length < 1
+      ) {
+        throw "Error: All fields are required to fill!";
+      }
+    } catch (error) {
+      console.log(error);
+      setErrorMsg(error);
+      showAlertHandler("fail");
+      setAlertTitle("Reset Password Error");
+      setAlertCotent(error);
+      setOpenAlert(true);
+      return;
+    }
+    try {
+      if (!(met7Chars && met1Upper && met1Lower && met1Number && met1Special))
+        throw "Error: Password is not qualifed! Please choose another one";
+    } catch (error) {
+      console.log(error);
+      setErrorMsg(error);
+      showAlertHandler("fail");
+      setAlertTitle("Reset Password Error");
+      setAlertCotent(error);
+      setOpenAlert(true);
+      return;
+    }
+    try {
+      if (!rePasswordMatch || new_password !== re_new_password)
+        throw "Error: Re-input password not matched";
+    } catch (error) {
+      console.log(error);
+      setErrorMsg(error);
+      showAlertHandler("fail");
+      setAlertTitle("Reset Password Error");
+      setAlertCotent(error);
+      setOpenAlert(true);
+      return;
+    }
+
+    try {
+      const response = await Auth.forgotPasswordSubmit(
+        username,
+        verify_code,
+        new_password
+      );
+      console.log("Reset Password response: ", response);
+      setSuccessMsg("Password reset is successful! Please sign in");
+      showAlertHandler("success");
+      setAlertTitle("Reset Password Notice");
+      setAlertCotent("Password reset is successful!");
+      setOpenAlert(true);
+    } catch (error) {
+      console.log("Reset New Password error: ", error.message);
+
+      let error_msg = error.message;
+      if (error_msg.includes("code")) {
+        error_msg =
+          "Verification link has been expired, please proceed 'Forgot password' again.";
+      }
+      setAlertCotent("Password reset error: " + error_msg);
+      setOpenAlert(true);
+      setErrorMsg(error_msg);
+      showAlertHandler("fail");
+      setAlertTitle("Reset Password Error");
+    }
+    return;
+  };
+
+  const showAlertHandler = (type) => {
+    if (type === "success") {
+      setShowSuccess(true);
+      const timer = setTimeout(() => {
+        setShowSuccess(false);
+      }, 5000);
+    } else if (type === "fail") {
+      setShowFail(true);
+      const timer = setTimeout(() => {
+        setShowFail(false);
+      }, 5000);
+    }
+  };
+
+  const handleClickShowNewPassword = () => {
+    setShowNewPassword(!showNewPassword);
+  };
+
+  const handleClickShowReNewPassword = () => {
+    setShowReNewPassword(!showReNewPassword);
+  };
+
+  const handleChange = (event) => {
+    event.persist();
+    updateFormState(() => ({
+      ...formState,
+      [event.target.name]: event.target.value,
+    }));
+    if (event.target.name === "new_password") {
+      handlePasswordCheck(event.target.value);
+      if (event.target.value !== formState.re_new_password) {
+        setRePasswordMatch(false);
+      } else {
+        setRePasswordMatch(true);
+      }
+    }
+    if (event.target.name === "re_new_password") {
+      handleRePasswordCheck(event.target.value);
+    }
+  };
+
+  const handlePasswordCheck = (value) => {
+    const newVal = value;
+    var re1 = /.{7,}$/;
+    if (re1.test(newVal)) {
+      setMet7Chars(true);
+    } else {
+      setMet7Chars(false);
+    }
+    var re2 = /[A-Z]/;
+    if (re2.test(newVal)) {
+      setMet1Upper(true);
+    } else {
+      setMet1Upper(false);
+    }
+    var re3 = /[a-z]/;
+    if (re3.test(newVal)) {
+      setMet1Lower(true);
+    } else {
+      setMet1Lower(false);
+    }
+    var re4 = /[0-9]/;
+    if (re4.test(newVal)) {
+      setMet1Number(true);
+    } else {
+      setMet1Number(false);
+    }
+    var re5 = /[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/;
+    if (re5.test(newVal)) {
+      setMet1Special(true);
+    } else {
+      setMet1Special(false);
+    }
+  };
+
+  const handleRePasswordCheck = (value) => {
+    const newVal = value;
+    if (newVal === formState.new_password) {
+      setRePasswordMatch(true);
+    } else {
+      setRePasswordMatch(false);
+    }
+  };
+
+  const handleGoHome = () => {
+    history.push("/");
+  };
+
+  return (
+    <div>
+      <AuthHeader location="Reset Password" />
+      <AlertDialog
+        title={alertTitle}
+        contentText={alertContent}
+        open={openAlert}
+        setOpen={setOpenAlert}
+        btn1Name="Back"
+        btn2Name="Home"
+        callBack={handleGoHome}
+      />
+      <div>
+        <Container component="main" maxWidth="xs">
+          <CssBaseline />
+          <div className={classes.paper}>
+            <Avatar className={classes.avatar}>
+              <LockOutlinedIcon />
+            </Avatar>
+            <Typography component="h1" variant="h5">
+              Reset Password
+            </Typography>
+            <form
+              className={classes.form}
+              noValidate
+              onSubmit={handleSumbitSetNewPassword}
+            >
+              <Grid container spacing={2}>
+                <Grid item xs={12}>
+                  <TextField
+                    variant="outlined"
+                    margin="normal"
+                    required
+                    fullWidth
+                    id="username"
+                    label="Username"
+                    name="username"
+                    onChange={handleChange}
+                  />
+                </Grid>
+                <Grid item xs={12}>
+                  <TextField
+                    variant="outlined"
+                    required
+                    fullWidth
+                    name="new_password"
+                    label="New Password"
+                    type={showNewPassword ? "text" : "password"}
+                    id="new_password"
+                    onChange={handleChange}
+                    InputProps={{
+                      endAdornment: (
+                        <InputAdornment position="end">
+                          <IconButton
+                            aria-label="toggle password visibility"
+                            onClick={handleClickShowNewPassword}
+                            edge="end"
+                          >
+                            {showNewPassword ? (
+                              <Visibility />
+                            ) : (
+                              <VisibilityOff />
+                            )}
+                          </IconButton>
+                        </InputAdornment>
+                      ),
+                    }}
+                  />
+                </Grid>
+                <Grid item xs={12}>
+                  <Typography>
+                    <p
+                      style={{ fontSize: 12 }}
+                      className={classes.passwordHint}
+                    >
+                      Password requirement: <br></br>
+                      <span
+                        className={
+                          met7Chars
+                            ? classes.passwordGreen
+                            : classes.passwordRed
+                        }
+                      >
+                        At least 7 characters long
+                      </span>
+                      <br></br>
+                      <span
+                        className={
+                          met1Upper
+                            ? classes.passwordGreen
+                            : classes.passwordRed
+                        }
+                      >
+                        Includes at least 1 UPPERCASE alphbet character
+                      </span>
+                      <br></br>
+                      <span
+                        className={
+                          met1Lower
+                            ? classes.passwordGreen
+                            : classes.passwordRed
+                        }
+                      >
+                        Includes at least 1 lowercase alphbet character
+                      </span>
+                      <br></br>
+                      <span
+                        className={
+                          met1Number
+                            ? classes.passwordGreen
+                            : classes.passwordRed
+                        }
+                      >
+                        Includes at least 1 number
+                      </span>
+                      <br></br>
+                      <span
+                        className={
+                          met1Special
+                            ? classes.passwordGreen
+                            : classes.passwordRed
+                        }
+                      >
+                        Includes at least 1 special sign from ! @ # $ % ^ & * (
+                        ) _ + - = [ ] &#123; &#125; ; ' : " \ | , . &#60; &#62;
+                        / ?
+                      </span>
+                      <br></br>
+                    </p>
+                  </Typography>
+                </Grid>
+                <Grid item xs={12}>
+                  <TextField
+                    variant="outlined"
+                    required
+                    fullWidth
+                    name="re_new_password"
+                    label="Re-input New Password"
+                    type={showReNewPassword ? "text" : "password"}
+                    id="re_new_password"
+                    onChange={handleChange}
+                    InputProps={{
+                      endAdornment: (
+                        <InputAdornment position="end">
+                          <IconButton
+                            aria-label="toggle password visibility"
+                            onClick={handleClickShowReNewPassword}
+                            edge="end"
+                          >
+                            {showReNewPassword ? (
+                              <Visibility />
+                            ) : (
+                              <VisibilityOff />
+                            )}
+                          </IconButton>
+                        </InputAdornment>
+                      ),
+                    }}
+                  />
+                </Grid>
+              </Grid>
+              <Grid item xs={12}>
+                {rePasswordMatch ? (
+                  <p
+                    className={classes.passwordGreen}
+                    style={{ marginTop: "1px" }}
+                  >
+                    Re-input password matched.
+                  </p>
+                ) : (
+                  <p
+                    className={classes.passwordRed}
+                    style={{ marginTop: "1px" }}
+                  >
+                    Re-input password not matched.
+                  </p>
+                )}
+              </Grid>
+              <Button
+                type="submit"
+                fullWidth
+                variant="contained"
+                color="primary"
+                className={classes.submit}
+              >
+                Set New Password
+              </Button>
+              <Grid container justify="flex-end">
+                <Grid item>
+                  <Link href="signin" variant="body2">
+                    Already have an account? Sign in
+                  </Link>
+                </Grid>
+              </Grid>
+            </form>
+          </div>
+          <Box mt={5}>
+            <Copyright />
+          </Box>
+        </Container>
+      </div>
+      <Fade in={showSuccess}>
+        <Alert variant="filled" severity="success" className={classes.alert}>
+          {successMsg || "Success"}
+        </Alert>
+      </Fade>
+      <Fade in={showFail}>
+        <Alert variant="filled" severity="error" className={classes.alert}>
+          {errorMsg || "Unknown error"}
+        </Alert>
+      </Fade>
+    </div>
+  );
+}

--- a/src/route/SignUp.js
+++ b/src/route/SignUp.js
@@ -91,7 +91,6 @@ export default function SignUp() {
   const [password, setPassword] = useState(null);
   const [showPassword, setShowPassword] = useState(false);
   const [rePassword, setRePassword] = useState(null);
-  const [invitation, setInvitation] = useState(null);
   const [showRePassword, setShowRePassword] = useState(false);
   const [showFail, setShowFail] = useState(false);
   const [errorMsg, setErrorMsg] = useState(null);
@@ -104,6 +103,7 @@ export default function SignUp() {
   const [openAlert, setOpenAlert] = useState(false);
   const [alertTitle, setAlertTitle] = useState("Notice");
   const [alertContent, setAlertCotent] = useState("");
+  const [agreeFeed, setAgreeFeed] = useState(false);
   const history = useHistory();
 
   const handleClickShowPassword = () => {
@@ -148,6 +148,11 @@ export default function SignUp() {
     }
 
     setPassword(newVal);
+    if (newVal !== rePassword) {
+      setRePasswordMatch(false);
+    } else {
+      setRePasswordMatch(true);
+    }
   };
 
   const handleRePasswordCheck = (event) => {

--- a/src/route/UserAgreementPage.js
+++ b/src/route/UserAgreementPage.js
@@ -1,0 +1,11 @@
+import UserAgreement from "../component/UserAgreement/UserAgreement";
+
+function SupportPage(props) {
+  return (
+    <div>
+      <UserAgreement />
+    </div>
+  );
+}
+
+export default UserAgreement;

--- a/src/route/VerifyAttributeWithCode.js
+++ b/src/route/VerifyAttributeWithCode.js
@@ -32,6 +32,7 @@ const useStyles = makeStyles((theme) => ({
 
 export default function VerifyAttributeWithCode(props) {
   const classes = useStyles();
+  // const [signedIn, setSignedIn] = useState(false);
   const [success, setSuccess] = useState(false);
   const [message, setMessage] = useState("Default message");
   const [countDowm, setCountDown] = useState(15);
@@ -41,15 +42,29 @@ export default function VerifyAttributeWithCode(props) {
   const history = useHistory();
 
   useEffect(() => {
-    handleVerify();
+    checkAuth();
   }, []);
 
-  useEffect(() => {
-    countDownHandler();
-    if (countDowm === 0) {
-      history.push("/");
+  async function checkAuth() {
+    try {
+      const authRes = await Auth.currentAuthenticatedUser();
+      handleVerify();
+      countDownHandler();
+      if (countDowm === 0) {
+        history.push("/");
+      }
+    } catch (error) {
+      console.log("On verify page, this user has not signed in yet.");
+      history.push("/resetpassword", { verify_code: code });
     }
-  });
+  }
+
+  // useEffect(() => {
+  //   countDownHandler();
+  //   if (countDowm === 0) {
+  //     history.push("/");
+  //   }
+  // });
 
   const countDownHandler = () => {
     const timer = setTimeout(() => {

--- a/src/route/VerifyEmail.js
+++ b/src/route/VerifyEmail.js
@@ -159,7 +159,7 @@ export default function VerifyEmail(props) {
             </Button>
             <p className={classes.helperText}>
               <Typography variant="caption">
-                Click the link coming to your email inbox after sending it.
+                Click the link in your email inbox to verify your email address
               </Typography>
             </p>
           </form>


### PR DESCRIPTION
Since all verification emails are all sent with link rather than
code, forgot password function needs a fix to adopt this change.
User click send verification email button on forgot password
page, then they will receive the "VerifyWithCode" link and click.
VerfifyWithCode sub-route will check if user signed in. If not,
redirect user to reset password. If signed in, it will complete
email verification process.
Also added "User Agreement" page. More help information was added
to notifiy email body.