### PR TITLE
Fix issue on all text and number input box

### DIFF
--- a/src/component/Admin/component/WriteIn/WriteIn.js
+++ b/src/component/Admin/component/WriteIn/WriteIn.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import Header from "./../../../Header";
 import Container from "@material-ui/core/Container";
+import { Box } from "@material-ui/core";
 import Stepper from "@material-ui/core/Stepper";
 import Step from "@material-ui/core/Step";
 import StepLabel from "@material-ui/core/StepLabel";
@@ -31,8 +32,11 @@ const useStyles = makeStyles((theme) => ({
     backgroundAttachment: "fixed",
     paddingTop: "130px",
     paddingBottom: theme.spacing(5),
+    display: "flex",
+    justifyContent: "center",
   },
   container: {
+    minWidth: "75vw",
     marginBottom: theme.spacing(5),
     padding: theme.spacing(5, 5, 1),
     backgroundColor: "white",
@@ -457,7 +461,7 @@ export default function WriteIn() {
     <div>
       <Header location="Admin Page" />
       <div className={classes.root}>
-        <Container maxWidth="lg" className={classes.container}>
+        <Box className={classes.container}>
           <div className={classes.title}>
             <Typography variant="h4" component="h4">
               Data Update and Create
@@ -585,7 +589,7 @@ export default function WriteIn() {
               </Button>
             </Paper>
           )}
-        </Container>
+        </Box>
       </div>
     </div>
   );

--- a/src/component/Admin/component/WriteIn/component/component/FloatNumberBox.js
+++ b/src/component/Admin/component/WriteIn/component/component/FloatNumberBox.js
@@ -89,7 +89,7 @@ export default function FloatNumberBox({
           <input
             type="text"
             defaultValue={value}
-            onChange={handleChange}
+            onInput={handleChange}
             className={invalid ? classes.errInput : classes.input}
           />
         </Box>

--- a/src/component/Admin/component/WriteIn/component/component/IntegerNumberBox.js
+++ b/src/component/Admin/component/WriteIn/component/component/IntegerNumberBox.js
@@ -90,7 +90,7 @@ export default function IntegerNumberBox({
           <input
             type="text"
             defaultValue={value}
-            onChange={handleChange}
+            onInput={handleChange}
             className={invalid ? classes.errInput : classes.input}
           />
         </Box>

--- a/src/component/Admin/component/WriteIn/component/component/TextBox.js
+++ b/src/component/Admin/component/WriteIn/component/component/TextBox.js
@@ -98,7 +98,7 @@ export default function TextBox({
           <input
             type="text"
             defaultValue={value}
-            onChange={handleChange}
+            onInput={handleChange}
             className={invalid ? classes.input_invalid : classes.input}
           />
         </Box>

--- a/src/component/Admin/component/WriteIn/component/component/TextBoxForHLA.js
+++ b/src/component/Admin/component/WriteIn/component/component/TextBoxForHLA.js
@@ -91,7 +91,7 @@ export default function TextBox({
           <input
             type="text"
             defaultValue={value}
-            onChange={handleChange}
+            onInput={handleChange}
             className={invalid ? classes.input_invalid : classes.input}
           />
         </Box>

--- a/src/component/Admin/component/WriteIn/component/component/TextBoxLarge.js
+++ b/src/component/Admin/component/WriteIn/component/component/TextBoxLarge.js
@@ -105,7 +105,7 @@ export default function TextBoxLarge({
           <textarea
             type="text"
             defaultValue={value || ""}
-            onChange={handleChange}
+            onInput={handleChange}
             className={invalid ? classes.errInput : classes.inputLarge}
           ></textarea>
         </Box>


### PR DESCRIPTION
Current issue all input box associated with 'onChange' event which
can't detect deleting all content at once by selecting all then
clicking backspace button. The solution is replace 'onChange' with
'onInput' event, which will instantly respond any changes.