### PR TITLE
Fix forgot_password logic

### DIFF
--- a/amplify/backend/function/emailFilterAuthTrigger/src/index.js
+++ b/amplify/backend/function/emailFilterAuthTrigger/src/index.js
@@ -17,22 +17,38 @@ exports.handler = (event, context, callback) => {
   // Identify why was this function invoked
   if (event.request.userAttributes["cognito:user_status"] === "CONFIRMED") {
     event.response.emailSubject = "nPOD Email Verification Link";
-    // event.response.emailMessage =
-    //   "Please click following link to verify your email on nPOD " +
-    //   event.request.linkParameter +
-    //   " If you don't recognize this email, please discard it and contact nPOD admin.";
-    var verifyUrl =
-      "https://portal.jdrfnpod.org/verify?attribute=email&verify_code=" +
-      event.request.codeParameter;
-    event.response.emailMessage =
-      "Please click following link to verify your email: " +
-      `<a href="${verifyUrl}">${verifyUrl}</a>` +
-      "<br>" +
-      "If you don't recognize this email, please discard it and report to nPOD admin." +
-      "<br>" +
-      "Sent at " +
-      dateTime +
-      " UTC";
+
+    if (event.triggerSource === "CustomMessage_VerifyUserAttribute") {
+      var verifyUrl =
+        "https://portal.jdrfnpod.org/verify?attribute=email&verify_code=" +
+        event.request.codeParameter +
+        "&action=verifyattribute";
+      event.response.emailMessage =
+        "Please click following link to verify your email: " +
+        `<a href="${verifyUrl}">${verifyUrl}</a>` +
+        "<br>" +
+        "If you don't recognize this email, please discard it and report to nPOD admin." +
+        "<br>" +
+        "Sent at " +
+        dateTime +
+        " UTC";
+    }
+
+    if (event.triggerSource === "CustomMessage_ForgotPassword") {
+      var verifyUrl =
+        "https://portal.jdrfnpod.org/verify?attribute=password&verify_code=" +
+        event.request.codeParameter +
+        "&action=forgotpassword";
+      event.response.emailMessage =
+        "Please click following link to verify your email: " +
+        `<a href="${verifyUrl}">${verifyUrl}</a>` +
+        "<br>" +
+        "If you don't recognize this email, please discard it and report to nPOD admin." +
+        "<br>" +
+        "Sent at " +
+        dateTime +
+        " UTC";
+    }
 
     // Return to Amazon Cognito
     context.done(null, event);

--- a/amplify/team-provider-info.json
+++ b/amplify/team-provider-info.json
@@ -24,7 +24,7 @@
         },
         "emailFilterAuthTrigger": {
           "deploymentBucketName": "amplify-amplifynpod-dev-163022-deployment",
-          "s3Key": "amplify-builds/emailFilterAuthTrigger-4169507433426c477636-build.zip"
+          "s3Key": "amplify-builds/emailFilterAuthTrigger-7330356a545531596538-build.zip"
         },
         "postConfirmAuthTrigger": {
           "deploymentBucketName": "amplify-amplifynpod-dev-163022-deployment",

--- a/src/route/VerifyAttributeWithCode.js
+++ b/src/route/VerifyAttributeWithCode.js
@@ -40,24 +40,16 @@ function VerifyAttributeWithCode(props) {
   const queryParams = new URLSearchParams(window.location.search);
   const attr = queryParams.get("attribute");
   const code = queryParams.get("verify_code");
+  const action = queryParams.get("action");
   const history = useHistory();
 
   useEffect(() => {
-    checkAuth();
-  }, []);
-
-  async function checkAuth() {
-    try {
+    if (action === "verifyattribute") {
       handleVerify();
-      countDownHandler();
-      if (countDowm === 0) {
-        history.push("/");
-      }
-    } catch (error) {
-      console.log("On verify page, this user has not signed in yet.");
+    } else if (action === "forgotpassword") {
       history.push("/resetpassword", { verify_code: code });
     }
-  }
+  }, []);
 
   useEffect(() => {
     countDownHandler();


### PR DESCRIPTION
When user clicks verify link without sign-in state, verify page
should redirect user to reset_password page to complete forgot
password action. Add one more layer logic to detect if user has
logged out.