### PR TITLE
admission_ABG_HCO3 low boundry is updated

### DIFF
--- a/src/component/Admin/component/WriteIn/component/HospitalLabs_step5.js
+++ b/src/component/Admin/component/WriteIn/component/HospitalLabs_step5.js
@@ -220,7 +220,7 @@ export default function HospitalLabs_step5({
     {
       colum: "admission_ABG_HCO3",
       input: "floatBox",
-      restrict: { type: "float", range: [10, 35] },
+      restrict: { type: "float", range: [0, 35] },
       valid: useState(true),
       ops: [],
     },


### PR DESCRIPTION
New data in this entry is 5.3 which less than the old low limit
10. The new low limit will be 0.