### PR TITLE
Fix the user group identify

### DIFF
--- a/src/route/AdminPage.js
+++ b/src/route/AdminPage.js
@@ -16,11 +16,12 @@ export default function AdminPage() {
       console.log("Check auth response ", authRes);
       console.log(
         "user group",
-        authRes.signInUserSession.accessToken.payload["cognito:groups"][0]
+        authRes.signInUserSession.accessToken.payload["cognito:groups"]
       );
       if (
-        authRes.signInUserSession.accessToken.payload["cognito:groups"][0] ===
-        "admin"
+        authRes.signInUserSession.accessToken.payload[
+          "cognito:groups"
+        ].includes("admin")
       ) {
         setAdminAccess(true);
         console.log("Welcome to admin page!");

--- a/src/route/DatasetSubmitPage.js
+++ b/src/route/DatasetSubmitPage.js
@@ -16,11 +16,12 @@ function DatasetSubmitPage(props) {
       console.log("Check auth response ", authRes);
       console.log(
         "user group",
-        authRes.signInUserSession.accessToken.payload["cognito:groups"][0]
+        authRes.signInUserSession.accessToken.payload["cognito:groups"]
       );
       if (
-        authRes.signInUserSession.accessToken.payload["cognito:groups"][0] ===
-        "dataset_user"
+        authRes.signInUserSession.accessToken.payload[
+          "cognito:groups"
+        ].includes("dataset_user")
       ) {
         console.log("Welcome to dataset page!");
       } else {


### PR DESCRIPTION
The user group identify works not as intended on Admin page, since user join more than one group scenario exists now. Fix by checking if object group in current user group list.