### PR TITLE
Update the url prefix of aperio image link

### DIFF
--- a/src/component/CaseView/component/TabView/component/Histopathology/Histopathology.js
+++ b/src/component/CaseView/component/TabView/component/Histopathology/Histopathology.js
@@ -42,7 +42,7 @@ function Histopathology(props) {
               type="Immunohistochemistry"
               exist={props.currentCase.Aperio_id}
               urlLinks={[
-                "https://aperioeslide.ahc.ufl.edu/eSlideTray.php?DisplayHeader=true&TableName=Case&Id=" +
+                "https://aperioeslide.ahc.ufl.edu/app/WebViewer/view/case/Id/" +
                   props.currentCase.Aperio_id,
               ]}
             />


### PR DESCRIPTION
Since Aperio website upadted their API of web viewer, the original link of Aperio images is no longer working. Updated with new prefix plus the aperio ID.