### PR TITLE
Change the temporal table name

### DIFF
--- a/amplify/backend/function/expressLambdaNpod/src/service/createDatabase.js
+++ b/amplify/backend/function/expressLambdaNpod/src/service/createDatabase.js
@@ -762,7 +762,7 @@ async function create_dataset_example_data_file(datasetExampleDataFileObj) {
 async function create_new_rows_into_table(table_name, matrix) {
   let headers = Object.keys(matrix[0]);
 
-  let the_table_name = "HLA_test"; // <=============== Temp table name, real one in the args
+  let the_table_name = "HLA_temp"; // <=============== Temp table name, real one in the args
   let sql1 = `INSERT INTO ${the_table_name}(`;
   let sql2 = "";
   headers.forEach((h) => {

--- a/amplify/backend/function/expressLambdaNpod/src/service/updateDatabase.js
+++ b/amplify/backend/function/expressLambdaNpod/src/service/updateDatabase.js
@@ -118,7 +118,7 @@ async function update_AAb(columns) {
 async function update_HLA(
   columns,
   isBatch = false,
-  tempTableName = "HLA_test"
+  tempTableName = "HLA_temp"
 ) {
   let updateStr = "";
   for (let [key, value] of Object.entries(columns)) {
@@ -258,7 +258,7 @@ async function batch_update_table(tableName, matrix) {
   switch (tableName) {
     case "HLA":
       updateFunc = update_HLA;
-      targetTable = "HLA_test";
+      targetTable = "HLA_temp";
   }
   for (const row of matrix) {
     let rowRes = updateFunc

--- a/amplify/team-provider-info.json
+++ b/amplify/team-provider-info.json
@@ -16,7 +16,7 @@
       "function": {
         "expressLambdaNpod": {
           "deploymentBucketName": "amplify-amplifynpod-dev-163022-deployment",
-          "s3Key": "amplify-builds/expressLambdaNpod-444f764773396152686f-build.zip"
+          "s3Key": "amplify-builds/expressLambdaNpod-4135346a42644e44346d-build.zip"
         },
         "AdminQueries0759059b": {
           "deploymentBucketName": "amplify-amplifynpod-dev-163022-deployment",

--- a/src/component/Admin/component/WriteIn/component/ImportData/component/ImportHLADataFile.js
+++ b/src/component/Admin/component/WriteIn/component/ImportData/component/ImportHLADataFile.js
@@ -211,13 +211,13 @@ export default function ImportHLADataFile() {
   useRetrieveTableHeaders("HLA", setTableHeaders);
   useRetrieveTableHeaders("RNA", setTableHeaders);
 
-  useRetrieveExisitingPrimaryKeyValues("HLA_test", setTablePrimaryKeyValues); // Note: testing set, need revert later
+  useRetrieveExisitingPrimaryKeyValues("HLA_temp", setTablePrimaryKeyValues); // Note: testing set, need revert later
   useRetrieveExisitingPrimaryKeyValues("RNA", setTablePrimaryKeyValues);
 
   useCheckImportFileFormat(
     "HLA",
     allRawFileData["HLA"],
-    allTablePrimaryKeyValues["HLA_test"], // Note: testing set, need revert later
+    allTablePrimaryKeyValues["HLA_temp"], // Note: testing set, need revert later
     HLAHeadersMapping,
     setDataToSend
   );


### PR DESCRIPTION
As implementation of HLA file importing function, we used HLA_test as temporal table. For convetion ease, it's been changed to HLA_temp from now on. Backend services are also updated.