### PR TITLE
Add dataset explore search filter

### DIFF
--- a/amplify/backend/function/expressLambdaNpod/src/app.js
+++ b/amplify/backend/function/expressLambdaNpod/src/app.js
@@ -71,6 +71,7 @@ var {
   update_slices_raw_data,
   update_immunophenotyping,
   batch_update_table,
+  get_data_by_conditions,
 } = require("./service/updateDatabase");
 
 var {
@@ -603,6 +604,16 @@ app.put("/db/batch_update_table", function (req, res) {
   console.log(req.body);
   batch_update_table(req.body["table_name"], req.body["matrix"]).then(
     (promiseRes) => res.send(promiseRes)
+  );
+});
+
+// get dataset by conditions
+app.put("/db/get_data_by_conditions", function (req, res) {
+  console.log("getting dataset by conditions...");
+  const table_name = req.body["table_name"];
+  const conditions = req.body["conditions"];
+  get_data_by_conditions(table_name, conditions).then((promoiseRes) =>
+    res.send(promoiseRes)
   );
 });
 

--- a/amplify/backend/function/expressLambdaNpod/src/service/readDatabase.js
+++ b/amplify/backend/function/expressLambdaNpod/src/service/readDatabase.js
@@ -366,7 +366,7 @@ async function get_table_column_headers_by_table_name(table_name) {
           reject(error);
         } else {
           console.log(
-            `[Fetch dataset] Totally ${result.length} column headers were fetched.`
+            `[Fetch table_column_headers_by_table_name] Totally ${result.length} column headers were fetched.`
           );
           let rt = result.map((item) => item.COLUMN_NAME);
           resolve(rt);
@@ -395,7 +395,7 @@ async function get_primary_key_values_by_table_name(table_name) {
           reject(error);
         } else {
           console.log(
-            `[Fetch dataset] Totally ${result[3].length} primary keys were fetched.`
+            `[Fetch primary_key_values_by_table_name] Totally ${result[3].length} primary keys were fetched.`
           );
           resolve(result[3]);
         }

--- a/amplify/backend/function/expressLambdaNpod/src/service/updateDatabase.js
+++ b/amplify/backend/function/expressLambdaNpod/src/service/updateDatabase.js
@@ -359,6 +359,58 @@ async function batch_update_table(tableName, matrix) {
   return await Promise.all(resList);
 }
 
+async function get_data_by_conditions(table_name, conditions) {
+  function parseCond(theCond) {
+    let sql = "";
+    if (
+      typeof theCond !== "object" ||
+      !theCond.hasOwnProperty("name") ||
+      !theCond.hasOwnProperty("operator" || !theCond.hasOwnProperty("value"))
+    ) {
+      return sql;
+    }
+    if (theCond.name === "LOGIC_CONNECT") {
+      let subCondList = theCond.value;
+      let subCondRtList = [];
+      subCondList.forEach((subCond) => {
+        let subRt = parseCond(subCond);
+        subCondRtList.push(subRt);
+      });
+      console.log("sub cond list result", subCondRtList);
+      let logic_connector = " " + theCond.operator + " ";
+      sql = subCondRtList.join(logic_connector);
+      sql = "(" + sql + ")";
+    } else {
+      if (theCond.operator === "NOT IN") {
+        sql = theCond.name + " " + theCond.operator + " " + theCond.value;
+      } else {
+        sql = theCond.name + theCond.operator + "'" + theCond.value + "'";
+      }
+    }
+    return sql;
+  }
+  const sqlCond = parseCond(conditions);
+  let sql = `SELECT * FROM ${table_name}`;
+  if (sqlCond !== "") {
+    sql = sql + " WHERE " + sqlCond;
+  }
+  console.log("sql query:", sql);
+
+  const asyncAction = async (newConnection) => {
+    return await new Promise((resolve, reject) => {
+      newConnection.query(sql, (error, result) => {
+        if (error) {
+          reject(error);
+        } else {
+          console.log(`[Fetch datasets_by_condition] fetch successful.`);
+          resolve(result);
+        }
+      });
+    });
+  };
+  return await pooledConnection(asyncAction);
+}
+
 module.exports = {
   testPoolForUpdate: testPoolForUpdate,
   update_case: update_case,
@@ -370,4 +422,5 @@ module.exports = {
   update_slices_raw_data: update_slices_raw_data,
   update_immunophenotyping: update_immunophenotyping,
   batch_update_table: batch_update_table,
+  get_data_by_conditions: get_data_by_conditions,
 };

--- a/amplify/team-provider-info.json
+++ b/amplify/team-provider-info.json
@@ -16,7 +16,7 @@
       "function": {
         "expressLambdaNpod": {
           "deploymentBucketName": "amplify-amplifynpod-dev-163022-deployment",
-          "s3Key": "amplify-builds/expressLambdaNpod-35614f4c5530334c4b68-build.zip"
+          "s3Key": "amplify-builds/expressLambdaNpod-2f704676676875773539-build.zip"
         },
         "AdminQueries0759059b": {
           "deploymentBucketName": "amplify-amplifynpod-dev-163022-deployment",

--- a/src/component/Dataset/DatasetDisplay/component/NormalDisplay.js
+++ b/src/component/Dataset/DatasetDisplay/component/NormalDisplay.js
@@ -343,19 +343,19 @@ export default function NormalDisplay({ datasetObj }) {
               type2="email"
             />
             <DataEntry
-              name="POC"
+              name="Point Of Contact"
               value={datasetObj.poc}
               value2={datasetObj.poc_email}
               type2="email"
             />
             <DataEntry
               name="Published"
-              value={datasetObj.published === 1 ? "True" : "False"}
+              value={datasetObj.published === 1 ? "Yes" : "No"}
             />
             <DataEntry
               name="PMID"
               value={
-                datasetObj.pmid != null ? datasetObj.pmid : "Not available"
+                datasetObj.pm_id === null ? "Not available" : datasetObj.pm_id
               }
             />
             <DataEntry

--- a/src/component/Dataset/DatasetExplore/DatasetExplore.js
+++ b/src/component/Dataset/DatasetExplore/DatasetExplore.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { styled } from "@mui/material/styles";
 import Box from "@mui/material/Box";
 import Paper from "@mui/material/Paper";
@@ -15,11 +15,36 @@ const PaperPanel = styled(Paper)(({ theme }) => ({
 
 export default function DatasetExplore() {
   const [filterSelected, setFilterSelected] = useState({
-    usageFilter: {},
-    datasetTypeFilter: {},
-    typeFilter: {},
-    caseIdFilter: {},
+    type: {},
+    category: {},
   });
+
+  const convertFilterToPathParams = (filtersCollection) => {
+    let pathParams = "?";
+    Object.keys(filtersCollection).forEach((filterName) => {
+      const currFilter = filtersCollection[filterName];
+      Object.keys(currFilter)
+        .filter((filterKey) => currFilter[filterKey] === true)
+        .forEach((selectedKey) => {
+          if (pathParams.length > 1) {
+            pathParams = pathParams + "&";
+          }
+          pathParams = pathParams + filterName + "=" + selectedKey;
+        });
+    });
+    console.log("path params", pathParams);
+    return pathParams;
+  };
+
+  // useEffect(() => {
+  //   setCurrPathParams(convertFilterToPathParams(filterSelected));
+
+  //   console.log("current path params", currPathParams);
+  // }, [filterSelected]);
+
+  // useEffect(() => {
+  //   window.history.pushState(null, "", `${currPathParams}`);
+  // }, [currPathParams]);
 
   const postObj = {
     name: "",
@@ -29,18 +54,23 @@ export default function DatasetExplore() {
     usage: "",
     dataType: "",
   };
-  console.log(filterSelected);
+  //console.log("filter selected", filterSelected);
 
   return (
     <Box
       sx={{
         //flexGrow: 1,
-        minHeight: "100vh",
+
         paddingBottom: 2,
         backgroundImage: `url(${
           process.env.PUBLIC_URL + "/assets/caseExplorePage.jpg"
         })`,
-        backgroundSize: "auto 100%",
+        // backgroundSize: "auto 100%",
+        backgroundSize: "cover",
+        width: "100%",
+        minHeight: "100vh",
+        backgroundAttachment: "fixed",
+        backgroundPosition: "center",
       }}
     >
       <Paper
@@ -57,10 +87,7 @@ export default function DatasetExplore() {
       <Grid container spacing={2} sx={{ padding: 5 }}>
         <Grid item xs={2} md={3}>
           <PaperPanel>
-            <Filter
-              filterSelected={filterSelected}
-              setFilterSelected={setFilterSelected}
-            />
+            <Filter />
           </PaperPanel>
         </Grid>
         <Grid item xs={6} md={8}>

--- a/src/component/Dataset/DatasetExplore/component/DatasetCardList.js
+++ b/src/component/Dataset/DatasetExplore/component/DatasetCardList.js
@@ -64,7 +64,7 @@ export default function DatasetCardList({ filterSelected }) {
     setDatasetRetrieveFail
   );
   console.log("all dataset", datasetObj);
-  console.log(filterSelected);
+
   return (
     <div style={{ paddingTop: "3vh" }}>
       {datasetObj !== null
@@ -72,6 +72,7 @@ export default function DatasetCardList({ filterSelected }) {
             // .filter((item) => filterSelected["usageFilter"][item.tag])
             .map((item, key) => (
               <div
+                key={key}
                 onClick={() => {
                   window.open(
                     `${window.location.origin}/dataset-display/${item.dataset_id}`

--- a/src/component/Dataset/DatasetExplore/component/Filter.js
+++ b/src/component/Dataset/DatasetExplore/component/Filter.js
@@ -13,53 +13,69 @@ import {
   Typography,
 } from "@mui/material";
 
-export default function Filter({ filterSelected, setFilterSelected }) {
-  // Usage filter setting
-  const [usage, setUsage] = useState({
-    RNASeq: true,
-    sequenceSpecificDNABinding: true,
-    transcriptomicData: true,
-  });
-  const { RNASeq, sequenceSpecificDNABinding, transcriptomicData } = usage;
+export default function Filter() {
+  const url = new URL(window.location.href);
+  const searchParameters = new URLSearchParams(url.search);
 
-  const handleUsageChange = (event) => {
-    setUsage(() => ({
-      ...usage,
-      [event.target.name]: event.target.checked,
-    }));
+  const baseUrl = url.origin + url.pathname;
+
+  const setFilterValue = (params, filterName) => {
+    for (const [name, value] of params.entries()) {
+      const optList = JSON.parse(value);
+      const selectedObj = optList.reduce((obj, item) => {
+        obj[item] = true;
+        return obj;
+      }, {});
+      if (name === filterName) {
+        return selectedObj;
+      }
+    }
+    return {};
   };
 
-  // Dataset Type filter setting
-  const [datasetType, setDatasetType] = useState({
-    transcriptomicDataSet: false,
-    genomicDataset: false,
-    epigennomicDataset: false,
-  });
-  const { transcriptomicDataSet, genomicDataset, epigennomicDataset } =
-    datasetType;
-  const hanldeDatasetTypeChange = (event) => {
-    setDatasetType(() => ({
-      ...datasetType,
-      [event.target.name]: event.target.checked,
-    }));
-  };
+  const type = setFilterValue(searchParameters, "type");
+  const category = setFilterValue(searchParameters, "category");
+  const published = setFilterValue(searchParameters, "published");
 
   // Type filter
-  const [type, setType] = useState({
-    genetics: false,
-    transcriptomics: false,
-    proteomics: false,
-    metabolomics: false,
-    imaging: false,
-  });
-
-  const { genetics, transcriptomics, proteomics, metabolomics, imaging } = type;
 
   const handleTypeChange = (event) => {
-    setType(() => ({
-      ...type,
-      [event.target.name]: event.target.checked,
-    }));
+    let newType = { ...type };
+    newType[event.target.name] = event.target.checked;
+    let newQueryParameters = generateQueryParameters(
+      newType,
+      category,
+      published
+    );
+    console.log("new query params", newQueryParameters);
+    window.location.href = url.pathname + "?" + newQueryParameters;
+  };
+
+  // Category filter
+
+  const handleCategoryChange = (event) => {
+    let newCategory = { ...category };
+    newCategory[event.target.name] = event.target.checked;
+    let newQueryParameters = generateQueryParameters(
+      type,
+      newCategory,
+      published
+    );
+    console.log("new query params", newQueryParameters);
+    window.location.href = url.pathname + "?" + newQueryParameters;
+  };
+
+  // Published filter
+  const handlePublishedChange = (event) => {
+    let newPublished = { ...published };
+    newPublished[event.target.name] = event.target.checked;
+    let newQueryParameters = generateQueryParameters(
+      type,
+      category,
+      newPublished
+    );
+    console.log("new query params", newQueryParameters);
+    window.location.href = url.pathname + "?" + newQueryParameters;
   };
 
   // Case ID filter
@@ -69,89 +85,48 @@ export default function Filter({ filterSelected, setFilterSelected }) {
     console.log("event target value", event.target.value);
   };
 
-  // Re-render after filters changed
-  useEffect(() => {
-    setFilterSelected({ usageFilter: usage, datasetTypeFilter: datasetType });
-  }, [usage, datasetType]);
+  const generateQueryParameters = (typeObj, categoryObj, publishedObj) => {
+    let qp = "";
+    let typeQuery = "[";
+    for (const [name, value] of Object.entries(typeObj)) {
+      if (value) {
+        if (typeQuery.length > 1) {
+          typeQuery = typeQuery + ",";
+        }
+        typeQuery = typeQuery + '"' + name + '"';
+      }
+    }
+    typeQuery = "type=" + typeQuery + "]";
+
+    let categoryQuery = "[";
+    for (const [name, value] of Object.entries(categoryObj)) {
+      if (value) {
+        if (categoryQuery.length > 1) {
+          categoryQuery = categoryQuery + ",";
+        }
+        categoryQuery = categoryQuery + '"' + name + '"';
+      }
+    }
+    categoryQuery = "category=" + categoryQuery + "]";
+
+    let publishedQuery = "[";
+    for (const [name, value] of Object.entries(publishedObj)) {
+      if (value) {
+        if (publishedQuery.length > 1) {
+          publishedQuery = publishedQuery + ",";
+        }
+        publishedQuery = publishedQuery + '"' + name + '"';
+      }
+    }
+    publishedQuery = "published=" + publishedQuery + "]";
+
+    qp = typeQuery + "&" + categoryQuery + "&" + publishedQuery;
+    return qp;
+  };
 
   const usageSubFilter = (
     <Box sx={{ display: "flex", flexDirection: "column" }}>
-      {/* ------Usage filter------ */}
-      {/* <FormControl sx={{ m: 3 }}>
-        <FormLabel>Usage</FormLabel>
-        <FormGroup sx={{ ml: 2 }}>
-          <FormControlLabel
-            label="RNA-Seq"
-            control={
-              <Checkbox
-                checked={RNASeq}
-                onChange={handleUsageChange}
-                name="RNASeq"
-              />
-            }
-          />
-          <FormControlLabel
-            label="sequence-specific DNA binding"
-            control={
-              <Checkbox
-                checked={sequenceSpecificDNABinding}
-                onChange={handleUsageChange}
-                name="sequenceSpecificDNABinding"
-              />
-            }
-          />
-          <FormControlLabel
-            label="transcriptomic data"
-            control={
-              <Checkbox
-                checked={transcriptomicData}
-                onChange={handleUsageChange}
-                name="transcriptomicData"
-              />
-            }
-          />
-        </FormGroup>
-      </FormControl> */}
-      {/* ------Dataset Type filter------ */}
-      {/* <FormControl sx={{ m: 3 }}>
-        <FormLabel>Dataset Type</FormLabel>
-        <FormGroup sx={{ ml: 2 }}>
-          <FormControlLabel
-            label="Transcriptomics Dataset"
-            control={
-              <Checkbox
-                checked={transcriptomicDataSet}
-                onChange={hanldeDatasetTypeChange}
-                name="transcriptomicDataSet"
-              />
-            }
-          />
-          <FormControlLabel
-            label="Genomics Dataset "
-            control={
-              <Checkbox
-                checked={genomicDataset}
-                onChange={hanldeDatasetTypeChange}
-                name="genomicDataset"
-              />
-            }
-          />
-          <FormControlLabel
-            label=" Epigenomics Dataset"
-            control={
-              <Checkbox
-                checked={epigennomicDataset}
-                onChange={hanldeDatasetTypeChange}
-                name="epigennomicDataset"
-              />
-            }
-          />
-        </FormGroup>
-      </FormControl> */}
       {/* ------Type filter------ */}
-      <Typography variant="h5" sx={{ marginTop: 3, marginLeft: 2 }}>
-        FOR DEMO ONLY
-      </Typography>
       <FormControl sx={{ m: 3 }}>
         <FormLabel>Type</FormLabel>
         <FormGroup sx={{ ml: 2 }}>
@@ -159,7 +134,7 @@ export default function Filter({ filterSelected, setFilterSelected }) {
             label="Genetics"
             control={
               <Checkbox
-                checked={genetics}
+                checked={"genetics" in type ? type.genetics : false}
                 onChange={handleTypeChange}
                 name="genetics"
               />
@@ -169,7 +144,9 @@ export default function Filter({ filterSelected, setFilterSelected }) {
             label="Transcriptomics"
             control={
               <Checkbox
-                checked={transcriptomics}
+                checked={
+                  "transcriptomics" in type ? type.transcriptomics : false
+                }
                 onChange={handleTypeChange}
                 name="transcriptomics"
               />
@@ -179,7 +156,7 @@ export default function Filter({ filterSelected, setFilterSelected }) {
             label="Proteomics"
             control={
               <Checkbox
-                checked={proteomics}
+                checked={"proteomics" in type ? type.proteomics : false}
                 onChange={handleTypeChange}
                 name="proteomics"
               />
@@ -189,19 +166,73 @@ export default function Filter({ filterSelected, setFilterSelected }) {
             label="Metabolomics"
             control={
               <Checkbox
-                checked={metabolomics}
+                checked={"metabolomics" in type ? type.metabolomics : false}
                 onChange={handleTypeChange}
                 name="metabolomics"
               />
             }
           />
           <FormControlLabel
-            label="Imaging"
+            label="Other"
             control={
               <Checkbox
-                checked={imaging}
+                checked={"other" in type ? type.other : false}
                 onChange={handleTypeChange}
-                name="imaging"
+                name="other"
+              />
+            }
+          />
+        </FormGroup>
+      </FormControl>
+      {/* ------Category filter------ */}
+      <FormControl sx={{ m: 3 }}>
+        <FormLabel>Category</FormLabel>
+        <FormGroup sx={{ ml: 2 }}>
+          <FormControlLabel
+            label="Investigator"
+            control={
+              <Checkbox
+                checked={
+                  "investigator" in category ? category.investigator : false
+                }
+                onChange={handleCategoryChange}
+                name="investigator"
+              />
+            }
+          />
+          <FormControlLabel
+            label="nPOD"
+            control={
+              <Checkbox
+                checked={"npod" in category ? category.npod : false}
+                onChange={handleCategoryChange}
+                name="npod"
+              />
+            }
+          />
+        </FormGroup>
+      </FormControl>
+      {/* ------Published filter------ */}
+      <FormControl sx={{ m: 3 }}>
+        <FormLabel>Published</FormLabel>
+        <FormGroup sx={{ ml: 2 }}>
+          <FormControlLabel
+            label="Yes"
+            control={
+              <Checkbox
+                checked={"yes" in published ? published.yes : false}
+                onChange={handlePublishedChange}
+                name="yes"
+              />
+            }
+          />
+          <FormControlLabel
+            label="No"
+            control={
+              <Checkbox
+                checked={"no" in published ? published.no : false}
+                onChange={handlePublishedChange}
+                name="no"
               />
             }
           />

--- a/src/component/Dataset/DatasetExplore/component/component/useRetrieveAllDatasets.js
+++ b/src/component/Dataset/DatasetExplore/component/component/useRetrieveAllDatasets.js
@@ -7,13 +7,124 @@ export default function useRetrieveAllDatasets(
   setDatasetRetrieveFail
 ) {
   useEffect(() => {
-    getAllDatasets();
+    const customizedCond = parseUrlParamsToApiCondObj();
+    if (
+      customizedCond.hasOwnProperty("value") &&
+      Array.isArray(customizedCond.value) &&
+      customizedCond.value.length !== 0
+    ) {
+      getDatasetsByConditions(customizedCond);
+    } else {
+      getAllDatasets();
+    }
   }, []);
+
+  function parseUrlParamsToApiCondObj() {
+    let apiCondObj = { ...templateParentAndCondition };
+    const url = new URL(window.location.href);
+    const searchParameters = new URLSearchParams(url.search);
+    for (const [name, value] of searchParameters.entries()) {
+      const filterValueArr = JSON.parse(value);
+      if (name === "type") {
+        const typeFilterObj = JSON.parse(
+          JSON.stringify(templateParentOrCondition)
+        );
+        filterValueArr.forEach((filterValue) => {
+          if (filterValue === "other") {
+            const currFilterObj = { ...templateChildNotInCondition };
+            currFilterObj.name = "dataset_type";
+            currFilterObj.value =
+              "('genetics', 'transcriptomics', 'metabolomics', 'proteomics')";
+            typeFilterObj.value.push(currFilterObj);
+          } else {
+            const currFilterObj = { ...templateChildEqualCondition };
+            currFilterObj.name = "dataset_type";
+            currFilterObj.value = filterValue;
+            typeFilterObj.value.push(currFilterObj);
+          }
+        });
+        apiCondObj.value.push(typeFilterObj);
+      }
+      if (name === "category") {
+        const categoryFilterObj = JSON.parse(
+          JSON.stringify(templateParentOrCondition)
+        );
+        filterValueArr.forEach((filterValue) => {
+          const currFilterObj = { ...templateChildEqualCondition };
+          currFilterObj.name = name;
+          currFilterObj.value = filterValue;
+          categoryFilterObj.value.push(currFilterObj);
+        });
+        apiCondObj.value.push(categoryFilterObj);
+      }
+
+      if (name === "published") {
+        const publishedFilterObj = JSON.parse(
+          JSON.stringify(templateParentOrCondition)
+        );
+        filterValueArr.forEach((filterValue) => {
+          const currFilterObj = { ...templateChildEqualCondition };
+          currFilterObj.name = name;
+          currFilterObj.value = filterValue === "yes" ? "1" : "0";
+          publishedFilterObj.value.push(currFilterObj);
+        });
+        apiCondObj.value.push(publishedFilterObj);
+      }
+    }
+    console.log("api condition object", apiCondObj);
+    return apiCondObj;
+  }
+
+  const templateParentAndCondition = {
+    name: "LOGIC_CONNECT",
+    operator: "AND",
+    value: [],
+  };
+
+  const templateParentOrCondition = {
+    name: "LOGIC_CONNECT",
+    operator: "OR",
+    value: [],
+  };
+
+  const templateChildEqualCondition = {
+    name: "",
+    operator: "=",
+    value: null,
+  };
+
+  const templateChildNotInCondition = {
+    name: "",
+    operator: "NOT IN",
+    value: "",
+  };
 
   async function getAllDatasets() {
     const nowTime = new Date().toLocaleString().replace(",", "");
     console.log("Retrieving all datasets...");
     return await API.get("dbapi", "/db/datasets", {})
+      .then((res) => {
+        console.log("Retrieve all dataset success!", res);
+        setDatasetObj(res);
+        setDatasetRetrieveSuccess("Retrieve Dataset create success!");
+        setDatasetRetrieveFail(null);
+      })
+      .catch((error) => {
+        console.log("New Dataset Create fail", error);
+        setDatasetRetrieveSuccess(null);
+        setDatasetRetrieveFail("Retrieve Dataset Create fail" + error);
+      });
+  }
+
+  async function getDatasetsByConditions(theConditions) {
+    const nowTime = new Date().toLocaleString().replace(",", "");
+    console.log("Retrieving datasets by conditions...");
+    return await API.put("dbapi", "/db/get_data_by_conditions", {
+      body: {
+        table_name: "dataset",
+        conditions: theConditions,
+      },
+    })
       .then((res) => {
         console.log("Retrieve all dataset success!", res);
         setDatasetObj(res);

--- a/src/component/Dataset/DatasetSubmit/component/component/useDownloadFile.js
+++ b/src/component/Dataset/DatasetSubmit/component/component/useDownloadFile.js
@@ -1,0 +1,30 @@
+import React, { useState, useEffect } from "react";
+import { Storage } from "aws-amplify";
+
+export default function useDownloadFile(
+  setCaseIdentifierExampleUrl,
+  setDownloadSuccess,
+  setDownloadError,
+  downloadButtonClicked,
+  handleButtonReset
+) {
+  useEffect(() => {
+    if (downloadButtonClicked === true) {
+      const fileKey = "documents/Case_Identifier_Example.csv";
+      downloadFile(fileKey);
+    }
+  }, [downloadButtonClicked]);
+
+  async function downloadFile(theFileKey) {
+    const nowTime = new Date().toLocaleString().replace(",", "");
+    try {
+      await Storage.get(theFileKey, { expires: 60 }).then((url) => {
+        setCaseIdentifierExampleUrl(url);
+      });
+      setDownloadSuccess("File download is successful");
+    } catch (error) {
+      setDownloadError("File download is failed", error);
+    }
+    handleButtonReset();
+  }
+}

--- a/src/route/DatasetExplorePage.js
+++ b/src/route/DatasetExplorePage.js
@@ -13,6 +13,28 @@ function DatasetExplorePage(props) {
   async function checkAuth() {
     try {
       const authRes = await Auth.currentAuthenticatedUser();
+      console.log("Check auth response ", authRes);
+      console.log(
+        "user group",
+        authRes.signInUserSession.accessToken.payload["cognito:groups"]
+      );
+      if ("cognito:groups" in authRes.signInUserSession.accessToken.payload) {
+        if (
+          authRes.signInUserSession.accessToken.payload[
+            "cognito:groups"
+          ].includes("dataset_user") ||
+          authRes.signInUserSession.accessToken.payload[
+            "cognito:groups"
+          ].includes("admin")
+        ) {
+          console.log("Welcome to dataset page!");
+        } else {
+          history.push("/");
+          console.log(
+            "Dataset page accessing is failed, since you are not dataset user."
+          );
+        }
+      }
     } catch (error) {
       console.log(error);
       history.push("/signin");


### PR DESCRIPTION
This new type of filter allow user to memerize the current search filter configuration to the url. Then the url is share-able. When open the url, all filters are set as the url described.

Improved the dataset submit page. Now dataset type input only user to select pre-set type from the drop down menu rather than free typing string. And case identifier example download is added as well.