### PR TITLE
create 'genetic' tab on case display

### DIFF
--- a/amplify/backend/function/expressLambdaNpod/src/app.js
+++ b/amplify/backend/function/expressLambdaNpod/src/app.js
@@ -27,6 +27,8 @@ var {
   get_caseId_by_datasetId,
   get_table_column_headers_by_table_name,
   get_primary_key_values_by_table_name,
+  get_genetic,
+  get_SNP,
 } = require("./service/readDatabase");
 
 var {
@@ -238,6 +240,18 @@ app.get("/db/primary_key_values_by_table_name", function (req, res) {
   get_primary_key_values_by_table_name(req.query.table_name).then(
     (promisedRes) => res.send(promisedRes)
   );
+});
+
+// get genetic
+app.get("/db/genetic", function (req, res) {
+  console.log("fetching genetic.");
+  get_genetic().then((promisedRes) => res.send(promisedRes));
+});
+
+// get genetic
+app.get("/db/SNP", function (req, res) {
+  console.log("fetching SNP.");
+  get_SNP().then((promisedRes) => res.send(promisedRes));
 });
 
 /****************************
@@ -511,8 +525,6 @@ app.post("/db/create_dataset_example_data_file", function (req, res) {
 });
 
 // create_new_rows_into_table
-
-// create dataset_example_data_file
 app.post("/db/create_new_rows_into_table", function (req, res) {
   console.log(`creating new rows into the table ${req.body.table_name}`);
   console.log(req.body);

--- a/amplify/backend/function/expressLambdaNpod/src/service/readDatabase.js
+++ b/amplify/backend/function/expressLambdaNpod/src/service/readDatabase.js
@@ -405,6 +405,46 @@ async function get_primary_key_values_by_table_name(table_name) {
   return await pooledConnection(asyncAction);
 }
 
+// get ALL from genetic table
+async function get_genetic() {
+  const sql = "SELECT * FROM `genetic`";
+  const asyncAction = async (newConnection) => {
+    return await new Promise((resolve, reject) => {
+      newConnection.query(sql, (error, result) => {
+        if (error) {
+          reject(error);
+        } else {
+          console.log(
+            `[Fetch genetic] Totally ${result.length} genetic records were fetched.`
+          );
+          resolve(result);
+        }
+      });
+    });
+  };
+  return await pooledConnection(asyncAction);
+}
+
+// get ALL from SNP table
+async function get_SNP() {
+  const sql = "SELECT * FROM `SNP`";
+  const asyncAction = async (newConnection) => {
+    return await new Promise((resolve, reject) => {
+      newConnection.query(sql, (error, result) => {
+        if (error) {
+          reject(error);
+        } else {
+          console.log(
+            `[Fetch SNP] Totally ${result.length} SNP records were fetched.`
+          );
+          resolve(result);
+        }
+      });
+    });
+  };
+  return await pooledConnection(asyncAction);
+}
+
 module.exports = {
   testPoolForRead: testPoolForRead,
   get_cases: get_cases,
@@ -424,4 +464,6 @@ module.exports = {
   get_table_column_headers_by_table_name:
     get_table_column_headers_by_table_name,
   get_primary_key_values_by_table_name: get_primary_key_values_by_table_name,
+  get_genetic: get_genetic,
+  get_SNP: get_SNP,
 };

--- a/amplify/team-provider-info.json
+++ b/amplify/team-provider-info.json
@@ -16,7 +16,7 @@
       "function": {
         "expressLambdaNpod": {
           "deploymentBucketName": "amplify-amplifynpod-dev-163022-deployment",
-          "s3Key": "amplify-builds/expressLambdaNpod-2f704676676875773539-build.zip"
+          "s3Key": "amplify-builds/expressLambdaNpod-6a325662796368652f4f-build.zip"
         },
         "AdminQueries0759059b": {
           "deploymentBucketName": "amplify-amplifynpod-dev-163022-deployment",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@material-ui/data-grid": "^4.0.0-alpha.31",
         "@material-ui/icons": "^4.11.2",
         "@material-ui/lab": "^4.0.0-alpha.58",
+        "@mui/icons-material": "^5.15.15",
         "@mui/material": "^5.10.8",
         "@mui/styles": "^5.10.8",
         "@mui/x-data-grid": "^6.0.1",
@@ -5976,6 +5977,47 @@
         "type": "opencollective",
         "url": "https://opencollective.com/mui"
       }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "5.15.15",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.15.15.tgz",
+      "integrity": "sha512-kkeU/pe+hABcYDH6Uqy8RmIsr2S/y5bP2rp+Gat4CcRjCcVne6KudS1NrZQhUCRysrTDCAhcbcf9gt+/+pGO2g==",
+      "dependencies": {
+        "@babel/runtime": "^7.23.9"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/icons-material/node_modules/@babel/runtime": {
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
+      "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@mui/icons-material/node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/@mui/material": {
       "version": "5.10.8",
@@ -35193,6 +35235,29 @@
       "version": "5.10.8",
       "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.10.8.tgz",
       "integrity": "sha512-V5D7OInO4P9PdT/JACg7fwjbOORm3GklaMVgdGomjyxiyetgRND5CC9r35e1LK/DqHdoyDuhbFzdfrqWtpmEIw=="
+    },
+    "@mui/icons-material": {
+      "version": "5.15.15",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.15.15.tgz",
+      "integrity": "sha512-kkeU/pe+hABcYDH6Uqy8RmIsr2S/y5bP2rp+Gat4CcRjCcVne6KudS1NrZQhUCRysrTDCAhcbcf9gt+/+pGO2g==",
+      "requires": {
+        "@babel/runtime": "^7.23.9"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.24.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
+          "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
+          "requires": {
+            "regenerator-runtime": "^0.14.0"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.14.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+          "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+        }
+      }
     },
     "@mui/material": {
       "version": "5.10.8",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@material-ui/data-grid": "^4.0.0-alpha.31",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",
+    "@mui/icons-material": "^5.15.15",
     "@mui/material": "^5.10.8",
     "@mui/styles": "^5.10.8",
     "@mui/x-data-grid": "^6.0.1",
@@ -54,7 +55,7 @@
     "xlsx": "^0.17.0"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "react-scripts --openssl-legacy-provider start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/src/Redux/exploreReducer.js
+++ b/src/Redux/exploreReducer.js
@@ -71,6 +71,18 @@ const initialState = {
   cPeptidePositive: true,
   cPeptideNegative: true,
 
+  // Genetic
+  geneticEnable: false,
+  grs1ScoreMin: 0,
+  grs1ScoreMax: 0.5,
+  grs1ScoreRange: [0, 0.5],
+  grs2ScoreMin: 0,
+  grs2ScoreMax: 20,
+  grs2ScoreRange: [0, 20],
+  aagrsScoreMin: 0,
+  aagrsScoreMax: 15,
+  aagrsScoreRange: [0, 15],
+
   // Raw Data
   rawData: [],
 
@@ -106,12 +118,22 @@ const initialState = {
   electronMicroscopyChecked: false,
   highResHLAChecked: false,
   immunophenotypingChecked: false,
+  wholeExomeSequencingAvailable: false,
+  wholeExomeSequencingUnavailable: false,
+  snpsAvailable: false,
+  snpsUnavailable: false,
 
   // electron microscopy images map
   emiMap: null,
 
   // immunophenotyping map
   immunMap: null,
+
+  // genetic map
+  geneticMap: null,
+
+  // SNP
+  SNP: null,
 };
 
 const exploreReducer = (state = initialState, action) => {
@@ -126,6 +148,10 @@ const exploreReducer = (state = initialState, action) => {
         donorTypesMap: state.donorTypesMap,
         causeOfDeathMap: state.causeOfDeathMap,
         hlaMap: state.hlaMap,
+        emiMap: state.emiMap,
+        immunMap: state.immunMap,
+        geneticMap: state.geneticMap,
+        SNP: state.SNP,
       };
 
     // Age
@@ -414,6 +440,64 @@ const exploreReducer = (state = initialState, action) => {
         cPeptideNegative: action.value,
       };
 
+    // Genetic
+    case "SET_GENETIC_ENABLE":
+      return {
+        ...state,
+        geneticEnable: action.value,
+      };
+    case "SET_GRS1_SCORE_MIN":
+      return {
+        ...state,
+        grs1ScoreMin: action.value,
+      };
+    case "SET_GRS1_SCORE_MAX":
+      return {
+        ...state,
+        grs1ScoreMax: action.value,
+      };
+    case "SET_GRS1_SCORE_RANGE":
+      return {
+        ...state,
+        grs1ScoreRange: action.value,
+        grs1ScoreMin: action.value[0],
+        grs1ScoreMax: action.value[1],
+      };
+    case "SET_GRS2_SCORE_MIN":
+      return {
+        ...state,
+        grs2ScoreMin: action.value,
+      };
+    case "SET_GRS2_SCORE_MAX":
+      return {
+        ...state,
+        grs2ScoreMax: action.value,
+      };
+    case "SET_GRS2_SCORE_RANGE":
+      return {
+        ...state,
+        grs2ScoreRange: action.value,
+        grs2ScoreMin: action.value[0],
+        grs2ScoreMax: action.value[1],
+      };
+    case "SET_AAGRS_SCORE_MIN":
+      return {
+        ...state,
+        aagrsScoreMin: action.value,
+      };
+    case "SET_AAGRS_SCORE_MAX":
+      return {
+        ...state,
+        aagrsScoreMax: action.value,
+      };
+    case "SET_AAGRS_SCORE_RANGE":
+      return {
+        ...state,
+        aagrsScoreRange: action.value,
+        aagrsScoreMin: action.value[0],
+        aagrsScoreMax: action.value[1],
+      };
+
     // Raw Data
     case "SET_RAW_DATA":
       return {
@@ -512,6 +596,26 @@ const exploreReducer = (state = initialState, action) => {
         ...state,
         immunophenotypingChecked: action.value,
       };
+    case "SET_WHOLE_EXOME_SEQUENCING_AVAILABLE":
+      return {
+        ...state,
+        wholeExomeSequencingAvailable: action.value,
+      };
+    case "SET_WHOLE_EXOME_SEQUENCING_UNAVAILABLE":
+      return {
+        ...state,
+        wholeExomeSequencingUnavailable: action.value,
+      };
+    case "SET_SNPS_AVAILABLE":
+      return {
+        ...state,
+        snpsAvailable: action.value,
+      };
+    case "SET_SNPS_UNAVAILABLE":
+      return {
+        ...state,
+        snpsUnavailable: action.value,
+      };
 
     // electron microscopy images map
     case "SET_EMI_MAP":
@@ -525,6 +629,20 @@ const exploreReducer = (state = initialState, action) => {
       return {
         ...state,
         immunMap: action.value,
+      };
+
+    // genetic map
+    case "SET_GENETIC_MAP":
+      return {
+        ...state,
+        geneticMap: action.value,
+      };
+
+    // SNP table
+    case "SET_SNP":
+      return {
+        ...state,
+        SNP: action.value,
       };
 
     default:

--- a/src/component/CaseView/component/TabView/TabView.js
+++ b/src/component/CaseView/component/TabView/TabView.js
@@ -11,6 +11,7 @@ import CaseProcessingAndTissueQuality from "./component/CaseProcessingAndTissueQ
 import FunctionalAssay from "./component/FunctionalAssay/FunctionalAssay";
 import Histopathology from "./component/Histopathology/Histopathology";
 import Immunophenotyping from "./component/Immunophenotyping/Immunophenotyping";
+import Genetic from "./component/Genetic/Genetic";
 
 function TabPanel(props) {
   const { children, value, index, ...other } = props;
@@ -122,6 +123,7 @@ export default function TabView() {
             {...a11yProps(5)}
             className={classes.tab}
           />
+          <Tab label="GENETICS" {...a11yProps(6)} className={classes.tab} />
         </Tabs>
         <div className={classes.tabPanel}>
           <TabPanel value={value} index={0}>
@@ -141,6 +143,9 @@ export default function TabView() {
           </TabPanel>
           <TabPanel value={value} index={5}>
             <Immunophenotyping />
+          </TabPanel>
+          <TabPanel value={value} index={6}>
+            <Genetic />
           </TabPanel>
         </div>
       </Paper>

--- a/src/component/CaseView/component/TabView/component/Genetic/Genetic.js
+++ b/src/component/CaseView/component/TabView/component/Genetic/Genetic.js
@@ -1,0 +1,79 @@
+import React from "react";
+import { makeStyles } from "@material-ui/core/styles";
+import Grid from "@material-ui/core/Grid";
+import Paper from "@material-ui/core/Paper";
+import Box from "@material-ui/core/Box";
+import Typography from "@material-ui/core/Typography";
+import Divider from "@material-ui/core/Divider";
+import { connect } from "react-redux";
+import Score from "./component/Score";
+import Percentile from "./component/Percentile";
+import ScoreAndPercentile from "./component/ScoreAndPercentile";
+import Availability from "./component/Availability";
+import Admixture from "./component/Admixture";
+import GRS1Snps from "./component/GRS1Snps";
+import GRS2Snps from "./component/GRS2Snps";
+import AAGRSSnps from "./component/AAGRSSnps";
+import Reference from "./component/Reference";
+
+const useStyles = makeStyles((theme) => ({
+  title: {
+    paddingBottom: theme.spacing(2),
+  },
+  content: {
+    paddingTop: theme.spacing(2),
+  },
+  paper: {
+    padding: theme.spacing(2),
+    color: theme.palette.text.primary,
+    height: "70vh",
+    maxHeight: "75vh",
+    overflow: "auto",
+  },
+}));
+
+function Genetic(props) {
+  const classes = useStyles();
+
+  return (
+    <div>
+      <Grid container spacing={2} justify={"center"} alignItems={"stretch"}>
+        <Grid item xs={12} md={6} lg={4} xl={3}>
+          <Paper elevation={3} className={classes.paper}>
+            <ScoreAndPercentile />
+            {/* <Score />
+            <Percentile /> */}
+            <Availability />
+            <Admixture />
+            <Reference />
+          </Paper>
+        </Grid>
+        <Grid item xs={12} md={6} lg={2} xl={3}>
+          <Paper elevation={3} className={classes.paper}>
+            <GRS1Snps />
+          </Paper>
+        </Grid>
+        <Grid item xs={12} md={6} lg={2} xl={3}>
+          <Paper elevation={3} className={classes.paper}>
+            <GRS2Snps />
+          </Paper>
+        </Grid>
+        <Grid item xs={12} md={6} lg={2} xl={3}>
+          <Paper elevation={3} className={classes.paper}>
+            <AAGRSSnps />
+          </Paper>
+        </Grid>
+      </Grid>
+    </div>
+  );
+}
+
+// Subscribe
+const mapStateToProps = (state) => {
+  return {
+    // Filtered Data
+    currentCase: state.explore.currentCase,
+  };
+};
+
+export default connect(mapStateToProps, null)(Genetic);

--- a/src/component/CaseView/component/TabView/component/Genetic/component/AAGRSSnps.js
+++ b/src/component/CaseView/component/TabView/component/Genetic/component/AAGRSSnps.js
@@ -1,0 +1,168 @@
+import React from "react";
+import { connect } from "react-redux";
+import { makeStyles, withStyles } from "@material-ui/core/styles";
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableContainer from "@material-ui/core/TableContainer";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
+import Paper from "@material-ui/core/Paper";
+import Typography from "@material-ui/core/Typography";
+import Card from "@material-ui/core/Card";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import Tooltip from "@material-ui/core/Tooltip";
+
+const useStyles = makeStyles((theme) => ({
+  title: {
+    paddingBottom: theme.spacing(2),
+  },
+  title2: {
+    paddingTop: theme.spacing(2),
+    paddingBottom: theme.spacing(2),
+  },
+  container: {
+    maxHeight: "56vh",
+  },
+  table: {
+    paddingBottom: theme.spacing(2),
+  },
+  note: {
+    maxHeight: "25vh",
+    overflow: "auto",
+  },
+  noteText: {
+    padding: "10px",
+  },
+  infoIcon: {
+    fontSize: 10,
+    marginLeft: "3px",
+    color: "#0292FF",
+  },
+  infoText: {
+    padding: "10px",
+    textShadow: "0 0 20px white",
+  },
+}));
+
+const GeneticTooltip = withStyles((theme) => ({
+  tooltip: {
+    backgroundColor: "rgba(255, 255, 255, 0.95)",
+    color: "#000000",
+    border: "1px solid #dadde9",
+    maxWidth: "420px",
+    fontSize: 15,
+  },
+}))(Tooltip);
+
+function AAGRSSnps(props) {
+  const classes = useStyles();
+  const genetic = props.geneticMap[props.currentCase.case_id];
+
+  function createData(name, value) {
+    return { name, value };
+  }
+
+  const rows = [];
+
+  const genRows = (snpsStr) => {
+    const snpsArr = snpsStr.split(";");
+    snpsArr.forEach((snpStr) => {
+      let snpKey = snpStr.split(":")[0] ?? "Not Available";
+      const snpValue = snpStr.split(":")[1] ?? "Not Available";
+      const prefix = "AA_GRS_";
+      snpKey = snpKey.replace(new RegExp("^" + prefix), "");
+      rows.push(createData(snpKey, snpValue));
+    });
+  };
+
+  try {
+    genRows(genetic.AA_GRS_SNPs);
+  } catch (err) {
+    console.log("Fetching genetic SNPs data error", err);
+    rows.push(createData("Unavailable", "Unavailable"));
+  }
+
+  const genGenInfo = (snpName, grs) => {
+    let infoText = "SNP";
+    Object.keys(props.SNP).forEach((SNP_id) => {
+      let snpObj = props.SNP[SNP_id];
+      if (snpObj.SNP_name === snpName && snpObj.GRS === grs) {
+        let gene1 = snpObj?.gene_1;
+        let gene2 = snpObj?.gene_2;
+        let gene3 = snpObj?.gene_3;
+        infoText = (
+          <React.Fragment>
+            <div className={classes.infoText}>
+              Gene 1: {gene1}
+              {gene2 ? <div>Gene 2: {gene2}</div> : null}
+              {gene3 ? <div>Gene 3: {gene3}</div> : null}
+            </div>
+          </React.Fragment>
+        );
+      }
+    });
+    return infoText;
+  };
+
+  return (
+    <div>
+      <div>
+        <Typography variant="h5" className={classes.title}>
+          AAGRS SNPs
+        </Typography>
+      </div>
+      <div>
+        <TableContainer component={Paper} className={classes.container}>
+          <Table className={classes.table} size="small" stickyHeader>
+            <TableHead>
+              <TableRow>
+                <TableCell>Name</TableCell>
+                <TableCell align="right">Value</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {rows.map((row) => (
+                <TableRow key={row.name}>
+                  <TableCell component="th" scope="row">
+                    {row.name}{" "}
+                    {row.value !== "Unavailable" ? (
+                      <GeneticTooltip
+                        title={genGenInfo(row.name, "AAGRS")}
+                        placement="right"
+                      >
+                        <InfoOutlinedIcon
+                          sx={{ fontSize: 16, color: "#0292FF" }}
+                        />
+                      </GeneticTooltip>
+                    ) : null}
+                  </TableCell>
+                  <TableCell align="right">{row.value}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </div>
+    </div>
+  );
+}
+
+// Subscribe
+const mapStateToProps = (state) => {
+  return {
+    // Filtered Data
+    currentCase: state.explore.currentCase,
+
+    // Donor Types (map)
+    donorTypesMap: state.explore.donorTypesMap,
+
+    // genetic map
+    geneticMap: state.explore.geneticMap,
+
+    // SNP-gene
+    SNP: state.explore.SNP,
+  };
+};
+
+export default connect(mapStateToProps, null)(AAGRSSnps);

--- a/src/component/CaseView/component/TabView/component/Genetic/component/Admixture.js
+++ b/src/component/CaseView/component/TabView/component/Genetic/component/Admixture.js
@@ -1,0 +1,134 @@
+import React from "react";
+import { connect } from "react-redux";
+import { makeStyles } from "@material-ui/core/styles";
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableContainer from "@material-ui/core/TableContainer";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
+import Paper from "@material-ui/core/Paper";
+import Typography from "@material-ui/core/Typography";
+import Card from "@material-ui/core/Card";
+import { Chart } from "react-google-charts";
+
+const useStyles = makeStyles((theme) => ({
+  title: {
+    paddingTop: theme.spacing(2),
+    paddingBottom: theme.spacing(2),
+  },
+  title2: {
+    paddingTop: theme.spacing(2),
+    paddingBottom: theme.spacing(2),
+  },
+  container: {
+    maxHeight: "56vh",
+  },
+  table: {
+    paddingBottom: theme.spacing(2),
+  },
+  note: {
+    maxHeight: "25vh",
+    overflow: "auto",
+  },
+  noteText: {
+    padding: "10px",
+  },
+}));
+
+function Admixture(props) {
+  const classes = useStyles();
+  const genetic = props.geneticMap[props.currentCase.case_id];
+
+  const admixture = {
+    amr:
+      genetic && genetic.admixed_american_AMR
+        ? genetic.admixed_american_AMR
+        : 0,
+    eur: genetic && genetic.european_EUR ? genetic.european_EUR : 0,
+    sas: genetic && genetic.south_asian_SAS ? genetic.south_asian_SAS : 0,
+    afr: genetic && genetic.african_AFR ? genetic.african_AFR : 0,
+    eas: genetic && genetic.east_asian_EAS ? genetic.east_asian_EAS : 0,
+  };
+
+  const admixtureDict = {
+    amr: "American",
+    eur: "European",
+    sas: "South Asian",
+    afr: "African",
+    eas: "East Asian",
+  };
+
+  const admixtureSum = Object.values(admixture).reduce(
+    (acc, curr) => acc + curr,
+    0
+  );
+
+  let normalizedChartData = [["Race", "Ratio"]];
+  if (admixtureSum !== 0) {
+    const normalizedAdmixture = {
+      amr: Number((admixture.amr / admixtureSum).toFixed(3)),
+      eur: Number((admixture.eur / admixtureSum).toFixed(3)),
+      sas: Number((admixture.sas / admixtureSum).toFixed(3)),
+      afr: Number((admixture.afr / admixtureSum).toFixed(3)),
+      eas: Number((admixture.eas / admixtureSum).toFixed(3)),
+    };
+
+    const chartDataGen = (charObj) => {
+      let tempChartData = [["Race", "Ratio"]];
+      for (let [key, value] of Object.entries(charObj)) {
+        tempChartData.push([admixtureDict[key], value]);
+      }
+      return tempChartData;
+    };
+    normalizedChartData = chartDataGen(normalizedAdmixture);
+  }
+
+  console.log("normalized chart data", normalizedChartData);
+
+  return (
+    <div>
+      <div>
+        <Typography variant="h5" className={classes.title}>
+          Admixture
+        </Typography>
+      </div>
+      <div>
+        <Chart
+          chartType="PieChart"
+          height="400px"
+          data={normalizedChartData}
+          options={{
+            pieHole: 0.4,
+            is3D: false,
+            chartArea: {
+              left: 0,
+              width: "100%",
+            },
+            legend: {
+              textStyle: { color: "blue", fontSize: 15 },
+              position: "top",
+              maxLines: 3,
+            },
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+// Subscribe
+const mapStateToProps = (state) => {
+  return {
+    // Filtered Data
+    currentCase: state.explore.currentCase,
+
+    // Donor Types (map)
+    donorTypesMap: state.explore.donorTypesMap,
+
+    // genetic map
+    geneticMap: state.explore.geneticMap,
+  };
+};
+
+export default connect(mapStateToProps, null)(Admixture);

--- a/src/component/CaseView/component/TabView/component/Genetic/component/Availability.js
+++ b/src/component/CaseView/component/TabView/component/Genetic/component/Availability.js
@@ -1,0 +1,111 @@
+import React from "react";
+import { connect } from "react-redux";
+import { makeStyles } from "@material-ui/core/styles";
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableContainer from "@material-ui/core/TableContainer";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
+import Paper from "@material-ui/core/Paper";
+import Typography from "@material-ui/core/Typography";
+import Card from "@material-ui/core/Card";
+
+const useStyles = makeStyles((theme) => ({
+  title: {
+    paddingTop: theme.spacing(2),
+    paddingBottom: theme.spacing(2),
+  },
+  title2: {
+    paddingTop: theme.spacing(2),
+    paddingBottom: theme.spacing(2),
+  },
+  container: {
+    maxHeight: "56vh",
+  },
+  table: {
+    paddingBottom: theme.spacing(2),
+  },
+  note: {
+    maxHeight: "25vh",
+    overflow: "auto",
+  },
+  noteText: {
+    padding: "10px",
+  },
+}));
+
+function Availability(props) {
+  const classes = useStyles();
+  const genetic = props.geneticMap[props.currentCase.case_id];
+
+  function createData(name, value) {
+    return { name, value };
+  }
+
+  const rows = [
+    createData(
+      "Availability",
+      genetic && genetic.whole_exome_sequencing_available ? (
+        <React.Fragment>
+          <a
+            href="https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs002861.v1.p1"
+            target="_blank"
+          >
+            Available
+          </a>
+        </React.Fragment>
+      ) : (
+        "Unavailable"
+      )
+    ),
+  ];
+
+  return (
+    <div>
+      <div>
+        <Typography variant="h5" className={classes.title}>
+          Whole Exome Sequencing
+        </Typography>
+      </div>
+      <div>
+        <TableContainer component={Paper} className={classes.container}>
+          <Table className={classes.table} size="small" stickyHeader>
+            <TableHead>
+              <TableRow>
+                <TableCell>Name</TableCell>
+                <TableCell align="right">Value</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {rows.map((row) => (
+                <TableRow key={row.name}>
+                  <TableCell component="th" scope="row">
+                    {row.name}
+                  </TableCell>
+                  <TableCell align="right">{row.value}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </div>
+    </div>
+  );
+}
+
+// Subscribe
+const mapStateToProps = (state) => {
+  return {
+    // Filtered Data
+    currentCase: state.explore.currentCase,
+
+    // Donor Types (map)
+    donorTypesMap: state.explore.donorTypesMap,
+
+    // genetic map
+    geneticMap: state.explore.geneticMap,
+  };
+};
+
+export default connect(mapStateToProps, null)(Availability);

--- a/src/component/CaseView/component/TabView/component/Genetic/component/GRS1Snps.js
+++ b/src/component/CaseView/component/TabView/component/Genetic/component/GRS1Snps.js
@@ -1,0 +1,168 @@
+import React from "react";
+import { connect } from "react-redux";
+import { makeStyles, withStyles } from "@material-ui/core/styles";
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableContainer from "@material-ui/core/TableContainer";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
+import Paper from "@material-ui/core/Paper";
+import Typography from "@material-ui/core/Typography";
+import Card from "@material-ui/core/Card";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import Tooltip from "@material-ui/core/Tooltip";
+
+const useStyles = makeStyles((theme) => ({
+  title: {
+    paddingBottom: theme.spacing(2),
+  },
+  title2: {
+    paddingTop: theme.spacing(2),
+    paddingBottom: theme.spacing(2),
+  },
+  container: {
+    maxHeight: "56vh",
+  },
+  table: {
+    paddingBottom: theme.spacing(2),
+  },
+  note: {
+    maxHeight: "25vh",
+    overflow: "auto",
+  },
+  noteText: {
+    padding: "10px",
+  },
+  infoIcon: {
+    fontSize: 10,
+    marginLeft: "3px",
+    color: "#0292FF",
+  },
+  infoText: {
+    padding: "10px",
+    textShadow: "0 0 20px white",
+  },
+}));
+
+const GeneticTooltip = withStyles((theme) => ({
+  tooltip: {
+    backgroundColor: "rgba(255, 255, 255, 0.95)",
+    color: "#000000",
+    border: "1px solid #dadde9",
+    maxWidth: "420px",
+    fontSize: 15,
+  },
+}))(Tooltip);
+
+function GRS1Snps(props) {
+  const classes = useStyles();
+  const genetic = props.geneticMap[props.currentCase.case_id];
+
+  function createData(name, value) {
+    return { name, value };
+  }
+
+  const rows = [];
+
+  const genRows = (snpsStr) => {
+    const snpsArr = snpsStr.split(";");
+    snpsArr.forEach((snpStr) => {
+      let snpKey = snpStr.split(":")[0] ?? "Not Available";
+      const snpValue = snpStr.split(":")[1] ?? "Not Available";
+      const prefix = "GRS1_";
+      snpKey = snpKey.replace(new RegExp("^" + prefix), "");
+      rows.push(createData(snpKey, snpValue));
+    });
+  };
+
+  try {
+    genRows(genetic.GRS1_SNPs);
+  } catch (err) {
+    console.log("Fetching genetic SNPs data error", err);
+    rows.push(createData("Unavailable", "Unavailable"));
+  }
+
+  const genGenInfo = (snpName, grs) => {
+    let infoText = "SNP";
+    Object.keys(props.SNP).forEach((SNP_id) => {
+      let snpObj = props.SNP[SNP_id];
+      if (snpObj.SNP_name === snpName && snpObj.GRS === grs) {
+        let gene1 = snpObj?.gene_1;
+        let gene2 = snpObj?.gene_2;
+        let gene3 = snpObj?.gene_3;
+        infoText = (
+          <React.Fragment>
+            <div className={classes.infoText}>
+              Gene 1: {gene1}
+              {gene2 ? <div>Gene 2: {gene2}</div> : null}
+              {gene3 ? <div>Gene 3: {gene3}</div> : null}
+            </div>
+          </React.Fragment>
+        );
+      }
+    });
+    return infoText;
+  };
+
+  return (
+    <div>
+      <div>
+        <Typography variant="h5" className={classes.title}>
+          GRS1 SNPs
+        </Typography>
+      </div>
+      <div>
+        <TableContainer component={Paper} className={classes.container}>
+          <Table className={classes.table} size="small" stickyHeader>
+            <TableHead>
+              <TableRow>
+                <TableCell>Name</TableCell>
+                <TableCell align="right">Value</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {rows.map((row) => (
+                <TableRow key={row.name}>
+                  <TableCell component="th" scope="row">
+                    {row.name}{" "}
+                    {row.value !== "Unavailable" ? (
+                      <GeneticTooltip
+                        title={genGenInfo(row.name, "GRS1")}
+                        placement="right"
+                      >
+                        <InfoOutlinedIcon
+                          sx={{ fontSize: 16, color: "#0292FF" }}
+                        />
+                      </GeneticTooltip>
+                    ) : null}
+                  </TableCell>
+                  <TableCell align="right">{row.value}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </div>
+    </div>
+  );
+}
+
+// Subscribe
+const mapStateToProps = (state) => {
+  return {
+    // Filtered Data
+    currentCase: state.explore.currentCase,
+
+    // Donor Types (map)
+    donorTypesMap: state.explore.donorTypesMap,
+
+    // genetic map
+    geneticMap: state.explore.geneticMap,
+
+    // SNP-gene
+    SNP: state.explore.SNP,
+  };
+};
+
+export default connect(mapStateToProps, null)(GRS1Snps);

--- a/src/component/CaseView/component/TabView/component/Genetic/component/GRS2Snps.js
+++ b/src/component/CaseView/component/TabView/component/Genetic/component/GRS2Snps.js
@@ -1,0 +1,169 @@
+import React from "react";
+import { connect } from "react-redux";
+import { makeStyles, withStyles } from "@material-ui/core/styles";
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableContainer from "@material-ui/core/TableContainer";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
+import Paper from "@material-ui/core/Paper";
+import Typography from "@material-ui/core/Typography";
+import Card from "@material-ui/core/Card";
+import InfoIcon from "@mui/icons-material/Info";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import Tooltip from "@material-ui/core/Tooltip";
+
+const useStyles = makeStyles((theme) => ({
+  title: {
+    paddingBottom: theme.spacing(2),
+  },
+  title2: {
+    paddingTop: theme.spacing(2),
+    paddingBottom: theme.spacing(2),
+  },
+  container: {
+    maxHeight: "56vh",
+  },
+  table: {
+    paddingBottom: theme.spacing(2),
+  },
+  note: {
+    maxHeight: "25vh",
+    overflow: "auto",
+  },
+  noteText: {
+    padding: "10px",
+  },
+  infoIcon: {
+    fontSize: 10,
+    marginLeft: "3px",
+    color: "#0292FF",
+  },
+  infoText: {
+    padding: "10px",
+    textShadow: "0 0 20px white",
+  },
+}));
+
+const GeneticTooltip = withStyles((theme) => ({
+  tooltip: {
+    backgroundColor: "rgba(255, 255, 255, 0.95)",
+    color: "#000000",
+    border: "1px solid #dadde9",
+    maxWidth: "420px",
+    fontSize: 15,
+  },
+}))(Tooltip);
+
+function GRS2Snps(props) {
+  const classes = useStyles();
+  const genetic = props.geneticMap[props.currentCase.case_id];
+
+  function createData(name, value) {
+    return { name, value };
+  }
+
+  const rows = [];
+
+  const genRows = (snpsStr) => {
+    const snpsArr = snpsStr.split(";");
+    snpsArr.forEach((snpStr) => {
+      let snpKey = snpStr.split(":")[0] ?? "Not Available";
+      const snpValue = snpStr.split(":")[1] ?? "Not Available";
+      const prefix = "GRS2_";
+      snpKey = snpKey.replace(new RegExp("^" + prefix), "");
+      rows.push(createData(snpKey, snpValue));
+    });
+  };
+
+  try {
+    genRows(genetic.GRS2_SNPs);
+  } catch (err) {
+    console.log("Fetching genetic SNPs data error", err);
+    rows.push(createData("Unavailable", "Unavailable"));
+  }
+
+  const genGenInfo = (snpName, grs) => {
+    let infoText = "SNP";
+    Object.keys(props.SNP).forEach((SNP_id) => {
+      let snpObj = props.SNP[SNP_id];
+      if (snpObj.SNP_name === snpName && snpObj.GRS === grs) {
+        let gene1 = snpObj?.gene_1;
+        let gene2 = snpObj?.gene_2;
+        let gene3 = snpObj?.gene_3;
+        infoText = (
+          <React.Fragment>
+            <div className={classes.infoText}>
+              Gene 1: {gene1}
+              {gene2 ? <div>Gene 2: {gene2}</div> : null}
+              {gene3 ? <div>Gene 3: {gene3}</div> : null}
+            </div>
+          </React.Fragment>
+        );
+      }
+    });
+    return infoText;
+  };
+
+  return (
+    <div>
+      <div>
+        <Typography variant="h5" className={classes.title}>
+          GRS2 SNPs
+        </Typography>
+      </div>
+      <div>
+        <TableContainer component={Paper} className={classes.container}>
+          <Table className={classes.table} size="small" stickyHeader>
+            <TableHead>
+              <TableRow>
+                <TableCell>Name</TableCell>
+                <TableCell align="right">Value</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {rows.map((row) => (
+                <TableRow key={row.name}>
+                  <TableCell component="th" scope="row">
+                    {row.name}{" "}
+                    {row.value !== "Unavailable" ? (
+                      <GeneticTooltip
+                        title={genGenInfo(row.name, "GRS2")}
+                        placement="right"
+                      >
+                        <InfoOutlinedIcon
+                          sx={{ fontSize: 16, color: "#0292FF" }}
+                        />
+                      </GeneticTooltip>
+                    ) : null}
+                  </TableCell>
+                  <TableCell align="right">{row.value}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </div>
+    </div>
+  );
+}
+
+// Subscribe
+const mapStateToProps = (state) => {
+  return {
+    // Filtered Data
+    currentCase: state.explore.currentCase,
+
+    // Donor Types (map)
+    donorTypesMap: state.explore.donorTypesMap,
+
+    // genetic map
+    geneticMap: state.explore.geneticMap,
+
+    // SNP-gene
+    SNP: state.explore.SNP,
+  };
+};
+
+export default connect(mapStateToProps, null)(GRS2Snps);

--- a/src/component/CaseView/component/TabView/component/Genetic/component/Percentile.js
+++ b/src/component/CaseView/component/TabView/component/Genetic/component/Percentile.js
@@ -1,0 +1,114 @@
+import React from "react";
+import { connect } from "react-redux";
+import { makeStyles } from "@material-ui/core/styles";
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableContainer from "@material-ui/core/TableContainer";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
+import Paper from "@material-ui/core/Paper";
+import Typography from "@material-ui/core/Typography";
+import Card from "@material-ui/core/Card";
+
+const useStyles = makeStyles((theme) => ({
+  title: {
+    paddingTop: theme.spacing(2),
+    paddingBottom: theme.spacing(2),
+  },
+  title2: {
+    paddingTop: theme.spacing(2),
+    paddingBottom: theme.spacing(2),
+  },
+  container: {
+    maxHeight: "56vh",
+  },
+  table: {
+    paddingBottom: theme.spacing(2),
+  },
+  note: {
+    maxHeight: "25vh",
+    overflow: "auto",
+  },
+  noteText: {
+    padding: "10px",
+  },
+}));
+
+function Percentile(props) {
+  const classes = useStyles();
+  const genetic = props.geneticMap[props.currentCase.case_id];
+
+  function createData(name, value) {
+    return { name, value };
+  }
+
+  const rows = [
+    createData(
+      "GRS1 Percentile",
+      genetic && genetic.GRS1_percentile
+        ? genetic.GRS1_percentile.toFixed(2)
+        : "Unavailable"
+    ),
+    createData(
+      "GRS2 Percentile",
+      genetic && genetic.GRS2_percentile
+        ? genetic.GRS2_percentile.toFixed(2)
+        : "Unavailable"
+    ),
+    createData(
+      "AAGRS Percentile",
+      genetic && genetic.AA_GRS_percentile
+        ? genetic.AA_GRS_percentile.toFixed(2)
+        : "Unavailable"
+    ),
+  ];
+
+  return (
+    <div>
+      <div>
+        <Typography variant="h5" className={classes.title}>
+          Percentile
+        </Typography>
+      </div>
+      <div>
+        <TableContainer component={Paper} className={classes.container}>
+          <Table className={classes.table} size="small" stickyHeader>
+            <TableHead>
+              <TableRow>
+                <TableCell>Name</TableCell>
+                <TableCell align="right">Value</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {rows.map((row) => (
+                <TableRow key={row.name}>
+                  <TableCell component="th" scope="row">
+                    {row.name}
+                  </TableCell>
+                  <TableCell align="right">{row.value}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </div>
+    </div>
+  );
+}
+
+// Subscribe
+const mapStateToProps = (state) => {
+  return {
+    // Filtered Data
+    currentCase: state.explore.currentCase,
+
+    // Donor Types (map)
+    donorTypesMap: state.explore.donorTypesMap,
+
+    // genetic map
+    geneticMap: state.explore.geneticMap,
+  };
+};
+
+export default connect(mapStateToProps, null)(Percentile);

--- a/src/component/CaseView/component/TabView/component/Genetic/component/Reference.js
+++ b/src/component/CaseView/component/TabView/component/Genetic/component/Reference.js
@@ -1,0 +1,96 @@
+import React from "react";
+import { connect } from "react-redux";
+import { makeStyles } from "@material-ui/core/styles";
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableContainer from "@material-ui/core/TableContainer";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
+import Paper from "@material-ui/core/Paper";
+import Typography from "@material-ui/core/Typography";
+import Card from "@material-ui/core/Card";
+
+const useStyles = makeStyles((theme) => ({
+  title: {
+    paddingBottom: theme.spacing(2),
+  },
+  title2: {
+    paddingTop: theme.spacing(2),
+    paddingBottom: theme.spacing(2),
+  },
+  container: {
+    maxHeight: "56vh",
+  },
+  table: {
+    paddingBottom: theme.spacing(2),
+  },
+  note: {
+    maxHeight: "25vh",
+    overflow: "auto",
+  },
+  noteText: {
+    padding: "10px",
+  },
+}));
+
+export default function Reference() {
+  const classes = useStyles();
+
+  return (
+    <div>
+      <div>
+        <div>
+          <Typography variant="h5" className={classes.title2}>
+            See these references for detailed data generation and calculation
+          </Typography>
+        </div>
+        <div>
+          <Card variant="outlined" className={classes.note}>
+            <Typography
+              variant="body2"
+              component="p"
+              className={classes.noteText}
+            >
+              <h4>
+                <a
+                  href="https://doi.org/10.1038/s41597-023-02244-6"
+                  target="_blank"
+                >
+                  A genomic data archive from the Network for Pancreatic Organ
+                  donors with Diabetes
+                </a>
+              </h4>
+              <h4>
+                <a href="https://doi.org/10.2337/dc15-1111" target="_blank">
+                  A Type 1 Diabetes Genetic Risk Score Can Aid Discrimination
+                  Between Type 1 and Type 2 Diabetes in Young Adults
+                </a>
+              </h4>{" "}
+              <h4>
+                <a href="https://doi.org/10.2337/dc18-1785" target="_blank">
+                  Development and Standardization of an Improved Type 1 Diabetes
+                  Genetic Risk Score for Use in Newborn Screening and Incident
+                  Diagnosis
+                </a>
+              </h4>
+              <h4>
+                <a href="https://doi.org/10.2337/dc21-1254" target="_blank">
+                  Improving the Prediction of Type 1 Diabetes Across Ancestries
+                </a>
+              </h4>
+              <h4>
+                <a
+                  href="https://repository.niddk.nih.gov/studies/t1dgc/"
+                  target="_blank"
+                >
+                  Type 1 Diabetes Genetic Consortium (T1DGC)
+                </a>
+              </h4>
+            </Typography>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/component/CaseView/component/TabView/component/Genetic/component/Score.js
+++ b/src/component/CaseView/component/TabView/component/Genetic/component/Score.js
@@ -1,0 +1,109 @@
+import React from "react";
+import { connect } from "react-redux";
+import { makeStyles } from "@material-ui/core/styles";
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableContainer from "@material-ui/core/TableContainer";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
+import Paper from "@material-ui/core/Paper";
+import Typography from "@material-ui/core/Typography";
+import Card from "@material-ui/core/Card";
+
+const useStyles = makeStyles((theme) => ({
+  title: {
+    paddingBottom: theme.spacing(2),
+  },
+  title2: {
+    paddingTop: theme.spacing(2),
+    paddingBottom: theme.spacing(2),
+  },
+  container: {
+    maxHeight: "56vh",
+  },
+  table: {
+    paddingBottom: theme.spacing(2),
+  },
+  note: {
+    maxHeight: "25vh",
+    overflow: "auto",
+  },
+  noteText: {
+    padding: "10px",
+  },
+}));
+
+function Score(props) {
+  const classes = useStyles();
+  const genetic = props.geneticMap[props.currentCase.case_id];
+
+  function createData(name, value) {
+    return { name, value };
+  }
+
+  const rows = [
+    createData(
+      "GRS1 Score",
+      genetic && genetic.GRS1_score ? genetic.GRS1_score : "Unavailable"
+    ),
+    createData(
+      "GRS2 Score",
+      genetic && genetic.GRS2_score ? genetic.GRS2_score : "Unavailable"
+    ),
+    createData(
+      "AAGRS Score",
+      genetic && genetic.AA_GRS_score === null
+        ? genetic.AA_GRS_score
+        : "Unavailable"
+    ),
+  ];
+
+  return (
+    <div>
+      <div>
+        <Typography variant="h5" className={classes.title}>
+          Score
+        </Typography>
+      </div>
+      <div>
+        <TableContainer component={Paper} className={classes.container}>
+          <Table className={classes.table} size="small" stickyHeader>
+            <TableHead>
+              <TableRow>
+                <TableCell>Name</TableCell>
+                <TableCell align="right">Value</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {rows.map((row) => (
+                <TableRow key={row.name}>
+                  <TableCell component="th" scope="row">
+                    {row.name}
+                  </TableCell>
+                  <TableCell align="right">{row.value}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </div>
+    </div>
+  );
+}
+
+// Subscribe
+const mapStateToProps = (state) => {
+  return {
+    // Filtered Data
+    currentCase: state.explore.currentCase,
+
+    // Donor Types (map)
+    donorTypesMap: state.explore.donorTypesMap,
+
+    // genetic map
+    geneticMap: state.explore.geneticMap,
+  };
+};
+
+export default connect(mapStateToProps, null)(Score);

--- a/src/component/CaseView/component/TabView/component/Genetic/component/ScoreAndPercentile.js
+++ b/src/component/CaseView/component/TabView/component/Genetic/component/ScoreAndPercentile.js
@@ -1,0 +1,267 @@
+import React from "react";
+import { connect } from "react-redux";
+import { makeStyles, withStyles } from "@material-ui/core/styles";
+import Tooltip from "@material-ui/core/Tooltip";
+import HelpOutlineIcon from "@material-ui/icons/HelpOutline";
+
+// import Table from "@material-ui/core/Table";
+// import TableBody from "@material-ui/core/TableBody";
+// import TableCell from "@material-ui/core/TableCell";
+// import TableContainer from "@material-ui/core/TableContainer";
+// import TableHead from "@material-ui/core/TableHead";
+// import TableRow from "@material-ui/core/TableRow";
+
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+
+import Paper from "@material-ui/core/Paper";
+import Typography from "@material-ui/core/Typography";
+import Card from "@material-ui/core/Card";
+import { Chart } from "react-google-charts";
+import { Box } from "@mui/material";
+
+const useStyles = makeStyles((theme) => ({
+  title: {
+    paddingBottom: theme.spacing(2),
+  },
+  title2: {
+    paddingTop: theme.spacing(2),
+    paddingBottom: theme.spacing(2),
+  },
+  container: {
+    maxHeight: "56vh",
+  },
+  table: {
+    paddingBottom: theme.spacing(2),
+  },
+  note: {
+    maxHeight: "25vh",
+    overflow: "auto",
+  },
+  noteText: {
+    padding: "10px",
+  },
+  helpIcon: {
+    fontSize: 18,
+    color: "#0292FF",
+  },
+  helpText: {
+    padding: "10px",
+    textShadow: "0 0 20px white",
+  },
+}));
+
+const GeneticTooltip = withStyles((theme) => ({
+  tooltip: {
+    backgroundColor: "rgba(255, 255, 255, 0.95)",
+    color: "#000000",
+    border: "1px solid #dadde9",
+    maxWidth: "420px",
+    fontSize: 15,
+  },
+}))(Tooltip);
+
+function ScoreAndPercentile(props) {
+  const classes = useStyles();
+  const genetic = props.geneticMap[props.currentCase.case_id];
+
+  const helpText = (
+    <React.Fragment>
+      <div className={classes.helpText}>
+        Hint:
+        <br />
+        Comparison to T1D cases in T1D Genetic Consortium
+      </div>
+    </React.Fragment>
+  );
+
+  function createData(attrName, attrData1, attrData2, attrData3) {
+    return { attrName, attrData1, attrData2, attrData3 };
+  }
+
+  const rows = [
+    createData(
+      "Score",
+      genetic && genetic.GRS1_score ? genetic.GRS1_score : "Unavailable",
+      genetic && genetic.GRS2_score ? genetic.GRS2_score : "Unavailable",
+      genetic && genetic.AA_GRS_score ? genetic.AA_GRS_score : "Unavailable"
+    ),
+    createData(
+      "Percentile",
+      genetic && genetic.GRS1_percentile
+        ? genetic.GRS1_percentile.toFixed(2)
+        : "Unavailable",
+      genetic && genetic.GRS2_percentile
+        ? genetic.GRS2_percentile.toFixed(2)
+        : "Unavailable",
+      genetic && genetic.AA_GRS_percentile
+        ? genetic.AA_GRS_percentile.toFixed(2)
+        : "Unavailable"
+    ),
+  ];
+
+  const GRS1PercentileDiffData = {
+    old: [
+      ["Name", "Percentile"],
+      ["GRS1", 100],
+    ],
+    new: [
+      ["Name", "Percentile"],
+      [
+        "GRS1",
+        genetic && genetic.GRS1_percentile ? genetic.GRS1_percentile : 0,
+      ],
+    ],
+  };
+
+  const GRS2PercentileDiffData = {
+    old: [
+      ["Name", "Percentile"],
+      ["GRS2", 100],
+    ],
+    new: [
+      ["Name", "Percentile"],
+      [
+        "GRS2",
+        genetic && genetic.GRS2_percentile ? genetic.GRS2_percentile : 0,
+      ],
+    ],
+  };
+
+  const AAGRSPercentileDiffData = {
+    old: [
+      ["Name", "Percentile"],
+      ["AAGRS", 100],
+    ],
+    new: [
+      ["Name", "Percentile"],
+      [
+        "AAGRS",
+        genetic && genetic.AA_GRS_percentile ? genetic.GRS1_percentile : 0,
+      ],
+    ],
+  };
+
+  const GRSPercentileDiffDataArr = [
+    GRS1PercentileDiffData,
+    GRS2PercentileDiffData,
+    AAGRSPercentileDiffData,
+  ];
+
+  return (
+    <div>
+      <div>
+        <Typography variant="h5" className={classes.title}>
+          Score & Percentile
+        </Typography>
+      </div>
+      <div>
+        <TableContainer
+          component={Paper}
+          className={classes.container}
+          sx={{ width: "max-content" }}
+        >
+          <Table className={classes.table} stickyHeader>
+            <TableHead>
+              <TableRow>
+                <TableCell></TableCell>
+                <TableCell
+                  align="center"
+                  sx={{ backgroundColor: "#BBDEFB", width: 70 }}
+                >
+                  GRS1
+                </TableCell>
+                <TableCell
+                  align="center"
+                  sx={{ backgroundColor: "#DCEDC8", width: 70 }}
+                >
+                  GRS2
+                </TableCell>
+                <TableCell
+                  align="center"
+                  sx={{ backgroundColor: "#FFF0B2", width: 70 }}
+                >
+                  AAGRS
+                </TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {rows.map((row) => (
+                <TableRow key={row.name}>
+                  <TableCell component="th" scope="row" variant="head">
+                    {row.attrName}{" "}
+                    {row.attrName === "Percentile" ? (
+                      <div style={{ lineHeight: 0.1 }}>
+                        <br></br>
+                        <GeneticTooltip title={helpText} placement="right">
+                          <HelpOutlineIcon className={classes.helpIcon} />
+                        </GeneticTooltip>
+                      </div>
+                    ) : null}
+                  </TableCell>
+                  <TableCell align="center">{row.attrData1}</TableCell>
+                  <TableCell align="center">{row.attrData2}</TableCell>
+                  <TableCell align="center">{row.attrData3}</TableCell>
+                </TableRow>
+              ))}
+
+              <TableRow>
+                <TableCell variant="head"></TableCell>
+                {GRSPercentileDiffDataArr.map((diffData, index) => (
+                  <TableCell style={{ minWidthwidth: "300px" }}>
+                    <Chart
+                      chartType="ColumnChart"
+                      width="100%"
+                      height="200px"
+                      diffdata={diffData}
+                      options={{
+                        tooltip: {
+                          trigger: "none",
+                        },
+                        theme: "maximized",
+                        legend: "none",
+                        diff: {
+                          oldData: {
+                            tooltip: {
+                              prefix: "label 1",
+                            },
+                          },
+                          newData: {
+                            widthFactor: 0.7,
+                            tooltip: {
+                              prefix: "label 2",
+                            },
+                          },
+                        },
+                      }}
+                    />
+                  </TableCell>
+                ))}
+              </TableRow>
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </div>
+    </div>
+  );
+}
+
+// Subscribe
+const mapStateToProps = (state) => {
+  return {
+    // Filtered Data
+    currentCase: state.explore.currentCase,
+
+    // Donor Types (map)
+    donorTypesMap: state.explore.donorTypesMap,
+
+    // genetic map
+    geneticMap: state.explore.geneticMap,
+  };
+};
+
+export default connect(mapStateToProps, null)(ScoreAndPercentile);

--- a/src/component/Dataset/DatasetExplore/component/Filter.js
+++ b/src/component/Dataset/DatasetExplore/component/Filter.js
@@ -37,6 +37,45 @@ export default function Filter() {
   const category = setFilterValue(searchParameters, "category");
   const published = setFilterValue(searchParameters, "published");
 
+  const generateQueryParameters = (typeObj, categoryObj, publishedObj) => {
+    let qp = "";
+    let typeQuery = "[";
+    for (const [name, value] of Object.entries(typeObj)) {
+      if (value) {
+        if (typeQuery.length > 1) {
+          typeQuery = typeQuery + ",";
+        }
+        typeQuery = typeQuery + '"' + name + '"';
+      }
+    }
+    typeQuery = "type=" + typeQuery + "]";
+
+    let categoryQuery = "[";
+    for (const [name, value] of Object.entries(categoryObj)) {
+      if (value) {
+        if (categoryQuery.length > 1) {
+          categoryQuery = categoryQuery + ",";
+        }
+        categoryQuery = categoryQuery + '"' + name + '"';
+      }
+    }
+    categoryQuery = "category=" + categoryQuery + "]";
+
+    let publishedQuery = "[";
+    for (const [name, value] of Object.entries(publishedObj)) {
+      if (value) {
+        if (publishedQuery.length > 1) {
+          publishedQuery = publishedQuery + ",";
+        }
+        publishedQuery = publishedQuery + '"' + name + '"';
+      }
+    }
+    publishedQuery = "published=" + publishedQuery + "]";
+
+    qp = typeQuery + "&" + categoryQuery + "&" + publishedQuery;
+    return qp;
+  };
+
   // Type filter
 
   const handleTypeChange = (event) => {
@@ -85,44 +124,35 @@ export default function Filter() {
     console.log("event target value", event.target.value);
   };
 
-  const generateQueryParameters = (typeObj, categoryObj, publishedObj) => {
-    let qp = "";
-    let typeQuery = "[";
-    for (const [name, value] of Object.entries(typeObj)) {
-      if (value) {
-        if (typeQuery.length > 1) {
-          typeQuery = typeQuery + ",";
-        }
-        typeQuery = typeQuery + '"' + name + '"';
-      }
-    }
-    typeQuery = "type=" + typeQuery + "]";
+  useEffect(() => {
+    if (searchParameters.toString() === "") {
+      const initType = {
+        genetics: true,
+        transcriptomics: true,
+        proteomics: true,
+        metabolomics: true,
+        other: true,
+      };
 
-    let categoryQuery = "[";
-    for (const [name, value] of Object.entries(categoryObj)) {
-      if (value) {
-        if (categoryQuery.length > 1) {
-          categoryQuery = categoryQuery + ",";
-        }
-        categoryQuery = categoryQuery + '"' + name + '"';
-      }
-    }
-    categoryQuery = "category=" + categoryQuery + "]";
+      const initCategory = {
+        investigator: true,
+        npod: true,
+      };
 
-    let publishedQuery = "[";
-    for (const [name, value] of Object.entries(publishedObj)) {
-      if (value) {
-        if (publishedQuery.length > 1) {
-          publishedQuery = publishedQuery + ",";
-        }
-        publishedQuery = publishedQuery + '"' + name + '"';
-      }
-    }
-    publishedQuery = "published=" + publishedQuery + "]";
+      const initPublished = {
+        yes: true,
+        no: true,
+      };
 
-    qp = typeQuery + "&" + categoryQuery + "&" + publishedQuery;
-    return qp;
-  };
+      const initQueryParameters = generateQueryParameters(
+        initType,
+        initCategory,
+        initPublished
+      );
+      console.log("init parameters", initQueryParameters);
+      window.location.href = url.pathname + "?" + initQueryParameters;
+    }
+  }, []);
 
   const usageSubFilter = (
     <Box sx={{ display: "flex", flexDirection: "column" }}>
@@ -239,7 +269,7 @@ export default function Filter() {
         </FormGroup>
       </FormControl>
       {/* ------Case ID filter------ */}
-      <FormControl sx={{ m: 3 }}>
+      {/* <FormControl sx={{ m: 3 }}>
         <FormLabel>Case ID</FormLabel>
         <Autocomplete
           sx={{ paddingLeft: 2 }}
@@ -262,7 +292,7 @@ export default function Filter() {
             />
           )}
         />
-      </FormControl>
+      </FormControl> */}
     </Box>
   );
 

--- a/src/component/Dataset/DatasetManage/component/DatasetCardList.js
+++ b/src/component/Dataset/DatasetManage/component/DatasetCardList.js
@@ -123,6 +123,22 @@ export default function DatasetCardList() {
             </div>
           ))
         : null}
+      {datasetObj?.length === 0 ? (
+        <Typography variant="h6" sx={{ padding: 3 }}>
+          Looks like you don't have any dataset in nPOD portal.
+          <br></br>
+          You can create a new one{" "}
+          <a href="/dataset-submit" target="_blank">
+            here
+          </a>
+          .<br></br>
+          Or browse existing datasets{" "}
+          <a href="/dataset-explore" target="_blank">
+            here
+          </a>
+          .
+        </Typography>
+      ) : null}
     </div>
   );
 }

--- a/src/component/Explore/component/Filter/Filter.js
+++ b/src/component/Explore/component/Filter/Filter.js
@@ -16,11 +16,12 @@ import FilterInsulitis from "./component/FilterInsulitis";
 import FilterCPeptide from "./component/FilterCPeptide";
 import FilterTitle from "./component/FilterTitle";
 import FilterDataset from "./component/FilterDataset";
+import FilterGenetic from "./component/FilterGenetic";
 
 const useStyles = makeStyles((theme) => ({
   root: {},
   filter: {
-    maxHeight: "65vh",
+    maxHeight: "80vh",
     // overflow: "auto",
     overflowX: "hidden",
     scrollbarGutter: "stable",
@@ -48,6 +49,7 @@ export default function Filter() {
         <FilterAutoAntibody />
         <FilterAutoAntibodyPositiveNumber />
         <FilterInsulitis />
+        <FilterGenetic />
       </div>
     </div>
   );

--- a/src/component/Explore/component/Filter/component/FilterDataset.js
+++ b/src/component/Explore/component/Filter/component/FilterDataset.js
@@ -204,6 +204,40 @@ function FilterDataset(props) {
                     label="Immunophenotyping"
                   />
                 </Box>
+                <Box>
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={props.wholeExomeSequencingAvailable}
+                        onChange={(event) =>
+                          props.setWholeExomeSequencingAvailable(
+                            event.target.checked
+                          )
+                        }
+                        name="wholeExomeSequencingAvailable"
+                        color="primary"
+                        disabled={!props.datasetEnable}
+                      />
+                    }
+                    label="Whole Exome Sequencing"
+                  />
+                </Box>
+                <Box>
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={props.snpsAvailable}
+                        onChange={(event) =>
+                          props.setSnpsAvailable(event.target.checked)
+                        }
+                        name="snpsAvailable"
+                        color="primary"
+                        disabled={!props.datasetEnable}
+                      />
+                    }
+                    label="SNPs"
+                  />
+                </Box>
               </Box>
             </FormGroup>
           </Grid>
@@ -221,6 +255,8 @@ const mapStateToProps = (state) => {
     electronMicroscopyChecked: state.explore.electronMicroscopyChecked,
     highResHLAChecked: state.explore.highResHLAChecked,
     immunophenotypingChecked: state.explore.immunophenotypingChecked,
+    wholeExomeSequencingAvailable: state.explore.wholeExomeSequencingAvailable,
+    snpsAvailable: state.explore.snpsAvailable,
   };
 };
 
@@ -246,6 +282,13 @@ const mapDispatchToProps = (dispatch) => {
         type: "SET_IMMUNOPHENOTYPING_CHECKED_ENABLE",
         value: checked,
       }),
+    setWholeExomeSequencingAvailable: (newWholeExomeSequencingAvailable) =>
+      dispatch({
+        type: "SET_WHOLE_EXOME_SEQUENCING_AVAILABLE",
+        value: newWholeExomeSequencingAvailable,
+      }),
+    setSnpsAvailable: (newSnpsAvailable) =>
+      dispatch({ type: "SET_SNPS_AVAILABLE", value: newSnpsAvailable }),
   };
 };
 

--- a/src/component/Explore/component/Filter/component/FilterGenetic.js
+++ b/src/component/Explore/component/Filter/component/FilterGenetic.js
@@ -1,0 +1,618 @@
+import React, { useState, useEffect } from "react";
+import { makeStyles, withStyles } from "@material-ui/core/styles";
+import Grid from "@material-ui/core/Grid";
+import Typography from "@material-ui/core/Typography";
+import Slider from "@material-ui/core/Slider";
+import TextField from "@material-ui/core/TextField";
+import Box from "@material-ui/core/Box";
+import Switch from "@material-ui/core/Switch";
+import { connect } from "react-redux";
+import Collapse from "@material-ui/core/Collapse";
+import IconButton from "@material-ui/core/IconButton";
+import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import clsx from "clsx";
+import Button from "@material-ui/core/Button";
+import Tooltip from "@material-ui/core/Tooltip";
+import HelpOutlineIcon from "@material-ui/icons/HelpOutline";
+
+const useStyles = makeStyles((theme) => ({
+  slider: {
+    width: "95%",
+    marginLeft: "5px",
+    // marginTop: "15px",
+    // marginBottom: "5px",
+  },
+  gridContainer: (props) => {
+    return props.geneticEnable
+      ? {
+          maxWidth: "90%",
+          marginLeft: "auto",
+          marginRight: "auto",
+          paddingTop: "5px",
+          paddingBottom: "5px",
+          borderTop: "1px solid #ccc",
+          borderLeft: "1px solid #ccc",
+          borderRight: "3px solid #b8b8b8",
+          borderBottom: "4px solid #b8b8b8",
+          borderRadius: "5px",
+          marginBottom: "5px",
+        }
+      : {};
+  },
+  gridItem: {
+    width: (props) => (props.geneticEnable ? "85%" : "75%"),
+  },
+  title: {
+    marginTop: theme.spacing(1),
+    // marginBottom: theme.spacing(1),
+    fontWeight: "600",
+    fontSize: "15px",
+    display: "flex",
+    alignItems: "center",
+    flexWrap: "wrap",
+  },
+  title2: {
+    marginTop: theme.spacing(1),
+    // marginBottom: theme.spacing(1),
+    fontWeight: "600",
+    fontSize: "13px",
+    display: "flex",
+    alignItems: "center",
+    flexWrap: "wrap",
+  },
+  switch: {
+    // marginTop: theme.spacing(2),
+    // marginBottom: theme.spacing(1),
+  },
+  expand: {
+    transform: "rotate(0deg)",
+    marginLeft: "auto",
+    transition: theme.transitions.create("transform", {
+      duration: theme.transitions.duration.shortest,
+    }),
+  },
+  expandOpen: {
+    transform: "rotate(180deg)",
+  },
+  expandBox: {
+    marginTop: "7px",
+  },
+  expendedTextfield: {
+    width: "80px",
+  },
+  expandedButton: {
+    height: "39px",
+    width: "65px",
+  },
+  helpIcon: {
+    fontSize: 18,
+    marginLeft: "3px",
+    color: "#0292FF",
+  },
+  helpIcon2: {
+    marginTop: "-10px",
+    marginBottom: "-10px",
+  },
+  helpText: {
+    padding: "10px",
+    textShadow: "0 0 20px white",
+  },
+}));
+
+const FilterTooltip = withStyles((theme) => ({
+  tooltip: {
+    backgroundColor: "rgba(255, 255, 255, 0.95)",
+    color: "#000000",
+    border: "1px solid #dadde9",
+    maxWidth: "420px",
+    fontSize: 15,
+  },
+}))(Tooltip);
+
+function FilterGenetic(props) {
+  const classes = useStyles(props);
+  const [expanded, setExpanded] = useState(false);
+  const [newGrs1Min, setNewGrs1Min] = useState(props.grs1ScoreMin);
+  const [newGrs1Max, setNewGrs1Max] = useState(props.grs1ScoreMax);
+  const [newGrs2Min, setNewGrs2Min] = useState(props.grs2ScoreMin);
+  const [newGrs2Max, setNewGrs2Max] = useState(props.grs2ScoreMax);
+  const [newAagrsMin, setNewAagrsMin] = useState(props.aagrsScoreMin);
+  const [newAagrsMax, setNewAagrsMax] = useState(props.aagrsScoreMax);
+  const [showError, setShowError] = useState(false);
+
+  const helpText = (
+    <React.Fragment>
+      <div className={classes.helpText}>
+        Hint:
+        <br />
+        When the switch is off (
+        <Switch color="primary" className={classes.helpIcon2} />) , the search
+        will ignore GRS score.
+        <br />
+        When the switch is on (
+        <Switch checked="true" color="primary" className={classes.helpIcon2} />)
+        , the search will find cases that match the given range.
+        <br />
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            flexWrap: "wrap",
+          }}
+        >
+          <span>Click the expand button (</span> <ExpandMoreIcon />
+          <span>) to input a specific number.</span>
+        </div>
+      </div>
+    </React.Fragment>
+  );
+
+  useEffect(() => {
+    if (!props.geneticEnable) {
+      setExpanded(false);
+    }
+  });
+
+  const handleExpandClick = () => {
+    setExpanded(!expanded);
+  };
+
+  const handleGrs1ScoreRangeSliderChange = (event, newGrs1ScoreRange) => {
+    props.setGrs1ScoreRange(newGrs1ScoreRange);
+  };
+
+  const handleGrs2ScoreRangeSliderChange = (event, newGrs2ScoreRange) => {
+    props.setGrs2ScoreRange(newGrs2ScoreRange);
+  };
+
+  const handleAagrsScoreRangeSliderChange = (event, newAagrsScoreRange) => {
+    props.setAagrsScoreRange(newAagrsScoreRange);
+  };
+
+  const handleMinGrs1ScoreInputChange = (event) => {
+    setNewGrs1Min(event.target.value);
+  };
+
+  const handleMinGrs2ScoreInputChange = (event) => {
+    setNewGrs2Min(event.target.value);
+  };
+
+  const handleMinAagrsScoreInputChange = (event) => {
+    setNewAagrsMin(event.target.value);
+  };
+
+  const handleMaxGrs1ScoreInputChange = (event) => {
+    setNewGrs1Max(event.target.value);
+  };
+
+  const handleMaxGrs2ScoreInputChange = (event) => {
+    setNewGrs2Max(event.target.value);
+  };
+
+  const handleMaxAagrsScoreInputChange = (event) => {
+    setNewAagrsMax(event.target.value);
+  };
+
+  const handleGrs1ScoreSet = () => {
+    const numMin = Number(newGrs1Min);
+    const numMax = Number(newGrs1Max);
+    if (
+      numMin != null &&
+      numMax != null &&
+      numMin <= numMax &&
+      numMin >= 0 &&
+      numMax <= 0.5
+    ) {
+      props.setGrs1ScoreMin(numMin);
+      props.setGrs1ScoreMax(numMax);
+      setShowError(false);
+    } else {
+      console.log("Invalid input!");
+      setShowError(true);
+    }
+  };
+
+  const handleGrs2ScoreSet = () => {
+    const numMin = Number(newGrs2Min);
+    const numMax = Number(newGrs2Max);
+    if (
+      numMin != null &&
+      numMax != null &&
+      numMin <= numMax &&
+      numMin >= 0 &&
+      numMax <= 20
+    ) {
+      props.setGrs2ScoreMin(newGrs2Min);
+      props.setGrs2ScoreMax(newGrs2Max);
+      setShowError(false);
+    } else {
+      console.log("Invalid input!");
+      setShowError(true);
+    }
+  };
+
+  const handleAagrsScoreSet = () => {
+    const numMin = Number(newAagrsMin);
+    const numMax = Number(newAagrsMax);
+    if (
+      numMin != null &&
+      numMax != null &&
+      numMin <= numMax &&
+      numMin >= 0 &&
+      numMax <= 15
+    ) {
+      props.setAagrsScoreMin(newAagrsMin);
+      props.setAagrsScoreMax(newAagrsMax);
+      setShowError(false);
+    } else {
+      console.log("Invalid input!");
+      setShowError(true);
+    }
+  };
+
+  const handleSwitch = (event) => {
+    props.setGeneticEnable(event.target.checked);
+    if (!event.target.checked) {
+      setExpanded(event.target.checked);
+    }
+  };
+
+  return (
+    <div>
+      <Grid
+        container
+        direction="column"
+        justify="center"
+        alignItems="center"
+        className={classes.gridContainer}
+      >
+        <Grid item xs={12} className={classes.gridItem}>
+          <Box display="flex">
+            <Box flexGrow={1}>
+              <Typography variant="subtitle1" className={classes.title}>
+                Genetics{"  "}
+                <FilterTooltip title={helpText} placement="right-start">
+                  <HelpOutlineIcon className={classes.helpIcon} />
+                </FilterTooltip>
+              </Typography>
+            </Box>
+            <Box>
+              <Switch
+                checked={props.geneticEnable}
+                onChange={handleSwitch}
+                name="grs1ScoreEnableSwitch"
+                className={classes.switch}
+                color="primary"
+              />
+            </Box>
+          </Box>
+        </Grid>
+        {/* GRS1 score slider */}
+        {props.geneticEnable && (
+          <Grid item xs={12} className={classes.gridItem}>
+            <Box display="flex" flexDirection="column">
+              <Box flexGrow={1}>
+                <Typography variant="subtitle1" className={classes.title2}>
+                  GRS1 Score{"  "}
+                  <FilterTooltip title={helpText} placement="right-start">
+                    <HelpOutlineIcon className={classes.helpIcon} />
+                  </FilterTooltip>
+                </Typography>
+              </Box>
+              <Box>
+                <Slider
+                  className={classes.slider}
+                  value={props.grs1ScoreRange}
+                  onChange={handleGrs1ScoreRangeSliderChange}
+                  disabled={!props.geneticEnable}
+                  valueLabelDisplay="auto"
+                  min={0}
+                  max={0.5}
+                  step={0.05}
+                  aria-labelledby="grs1-score-range-slider"
+                />
+              </Box>
+            </Box>
+          </Grid>
+        )}
+
+        {props.geneticEnable && (
+          <Grid item xs={12} className={classes.gridItem}>
+            <Grid container alignItems="center" justify="space-between">
+              <Grid item>
+                <Typography variant="body1" color="textPrimary">
+                  {props.grs1ScoreMin}
+                </Typography>
+              </Grid>
+              <Grid item>
+                <IconButton
+                  className={clsx(classes.expand, {
+                    [classes.expandOpen]: expanded,
+                  })}
+                  onClick={handleExpandClick}
+                  disabled={!props.geneticEnable}
+                >
+                  <ExpandMoreIcon />
+                </IconButton>
+              </Grid>
+              <Grid item>
+                <Typography variant="body1" color="textPrimary">
+                  {props.grs1ScoreMax}
+                </Typography>
+              </Grid>
+            </Grid>
+          </Grid>
+        )}
+
+        <Grid item xs={12} className={classes.gridItem}>
+          <Collapse in={expanded} timeout="auto" unmountOnExit>
+            <Box
+              display="flex"
+              justifyContent="space-between"
+              className={classes.expandBox}
+            >
+              <TextField
+                label="From"
+                variant="outlined"
+                className={classes.expendedTextfield}
+                defaultValue={props.grs1ScoreMin}
+                size="small"
+                onChange={handleMinGrs1ScoreInputChange}
+                error={showError}
+              />
+              <TextField
+                label="To"
+                variant="outlined"
+                className={classes.expendedTextfield}
+                defaultValue={props.grs1ScoreMax}
+                size="small"
+                onChange={handleMaxGrs1ScoreInputChange}
+                error={showError}
+              />
+              <Button
+                variant="contained"
+                color="primary"
+                className={classes.expandedButton}
+                onClick={handleGrs1ScoreSet}
+              >
+                SET
+              </Button>
+            </Box>
+          </Collapse>
+        </Grid>
+
+        {/* GRS2 score slider */}
+        {props.geneticEnable && (
+          <Grid item xs={12} className={classes.gridItem}>
+            <Box display="flex" flexDirection="column">
+              <Box flexGrow={1}>
+                <Typography variant="subtitle1" className={classes.title2}>
+                  GRS2 Score{"  "}
+                  <FilterTooltip title={helpText} placement="right-start">
+                    <HelpOutlineIcon className={classes.helpIcon} />
+                  </FilterTooltip>
+                </Typography>
+              </Box>
+              <Box>
+                <Slider
+                  className={classes.slider}
+                  value={props.grs2ScoreRange}
+                  onChange={handleGrs2ScoreRangeSliderChange}
+                  disabled={!props.geneticEnable}
+                  valueLabelDisplay="auto"
+                  min={0}
+                  max={20}
+                  step={1}
+                  aria-labelledby="grs2-score-range-slider"
+                />
+              </Box>
+            </Box>
+          </Grid>
+        )}
+
+        {props.geneticEnable && (
+          <Grid item xs={12} className={classes.gridItem}>
+            <Grid container alignItems="center" justify="space-between">
+              <Grid item>
+                <Typography variant="body1" color="textPrimary">
+                  {props.grs2ScoreMin}
+                </Typography>
+              </Grid>
+              <Grid item>
+                <IconButton
+                  className={clsx(classes.expand, {
+                    [classes.expandOpen]: expanded,
+                  })}
+                  onClick={handleExpandClick}
+                  disabled={!props.geneticEnable}
+                >
+                  <ExpandMoreIcon />
+                </IconButton>
+              </Grid>
+              <Grid item>
+                <Typography variant="body1" color="textPrimary">
+                  {props.grs2ScoreMax}
+                </Typography>
+              </Grid>
+            </Grid>
+          </Grid>
+        )}
+
+        <Grid item xs={12} className={classes.gridItem}>
+          <Collapse in={expanded} timeout="auto" unmountOnExit>
+            <Box
+              display="flex"
+              justifyContent="space-between"
+              className={classes.expandBox}
+            >
+              <TextField
+                label="From"
+                variant="outlined"
+                className={classes.expendedTextfield}
+                defaultValue={props.grs2ScoreMin}
+                size="small"
+                onChange={handleMinGrs2ScoreInputChange}
+                error={showError}
+              />
+              <TextField
+                label="To"
+                variant="outlined"
+                className={classes.expendedTextfield}
+                defaultValue={props.grs2ScoreMax}
+                size="small"
+                onChange={handleMaxGrs2ScoreInputChange}
+                error={showError}
+              />
+              <Button
+                variant="contained"
+                color="primary"
+                className={classes.expandedButton}
+                onClick={handleGrs2ScoreSet}
+              >
+                SET
+              </Button>
+            </Box>
+          </Collapse>
+        </Grid>
+
+        {/* AAGRS score slider */}
+        {props.geneticEnable && (
+          <Grid item xs={12} className={classes.gridItem}>
+            <Box display="flex" flexDirection="column">
+              <Box flexGrow={1}>
+                <Typography variant="subtitle1" className={classes.title2}>
+                  AAGRS Score{"  "}
+                  <FilterTooltip title={helpText} placement="right-start">
+                    <HelpOutlineIcon className={classes.helpIcon} />
+                  </FilterTooltip>
+                </Typography>
+              </Box>
+              <Box>
+                <Slider
+                  className={classes.slider}
+                  value={props.aagrsScoreRange}
+                  onChange={handleAagrsScoreRangeSliderChange}
+                  disabled={!props.geneticEnable}
+                  valueLabelDisplay="auto"
+                  min={0}
+                  max={15}
+                  step={1}
+                  aria-labelledby="aagrs-score-range-slider"
+                />
+              </Box>
+            </Box>
+          </Grid>
+        )}
+
+        {props.geneticEnable && (
+          <Grid item xs={12} className={classes.gridItem}>
+            <Grid container alignItems="center" justify="space-between">
+              <Grid item>
+                <Typography variant="body1" color="textPrimary">
+                  {props.aagrsScoreMin}
+                </Typography>
+              </Grid>
+              <Grid item>
+                <IconButton
+                  className={clsx(classes.expand, {
+                    [classes.expandOpen]: expanded,
+                  })}
+                  onClick={handleExpandClick}
+                  disabled={!props.geneticEnable}
+                >
+                  <ExpandMoreIcon />
+                </IconButton>
+              </Grid>
+              <Grid item>
+                <Typography variant="body1" color="textPrimary">
+                  {props.aagrsScoreMax}
+                </Typography>
+              </Grid>
+            </Grid>
+          </Grid>
+        )}
+
+        <Grid item xs={12} className={classes.gridItem}>
+          <Collapse in={expanded} timeout="auto" unmountOnExit>
+            <Box
+              display="flex"
+              justifyContent="space-between"
+              className={classes.expandBox}
+            >
+              <TextField
+                label="From"
+                variant="outlined"
+                className={classes.expendedTextfield}
+                defaultValue={props.aagrsScoreMin}
+                size="small"
+                onChange={handleMinAagrsScoreInputChange}
+                error={showError}
+              />
+              <TextField
+                label="To"
+                variant="outlined"
+                className={classes.expendedTextfield}
+                defaultValue={props.aagrsScoreMax}
+                size="small"
+                onChange={handleMaxAagrsScoreInputChange}
+                error={showError}
+              />
+              <Button
+                variant="contained"
+                color="primary"
+                className={classes.expandedButton}
+                onClick={handleAagrsScoreSet}
+              >
+                SET
+              </Button>
+            </Box>
+          </Collapse>
+        </Grid>
+      </Grid>
+    </div>
+  );
+}
+
+// subscribe
+const mapStateToProps = (state) => {
+  return {
+    geneticEnable: state.explore.geneticEnable,
+    grs1ScoreMin: state.explore.grs1ScoreMin,
+    grs1ScoreMax: state.explore.grs1ScoreMax,
+    grs1ScoreRange: state.explore.grs1ScoreRange,
+    grs2ScoreMin: state.explore.grs2ScoreMin,
+    grs2ScoreMax: state.explore.grs2ScoreMax,
+    grs2ScoreRange: state.explore.grs2ScoreRange,
+    aagrsScoreMin: state.explore.aagrsScoreMin,
+    aagrsScoreMax: state.explore.aagrsScoreMax,
+    aagrsScoreRange: state.explore.aagrsScoreRange,
+  };
+};
+
+// update
+const mapDispatchToProps = (dispatch) => {
+  return {
+    setGeneticEnable: (newGeneticEnable) =>
+      dispatch({ type: "SET_GENETIC_ENABLE", value: newGeneticEnable }),
+    setGrs1ScoreMin: (newGrs1ScoreMin) =>
+      dispatch({ type: "SET_GRS1_SCORE_MIN", value: newGrs1ScoreMin }),
+    setGrs1ScoreMax: (newGrs1ScoreMax) =>
+      dispatch({ type: "SET_GRS1_SCORE_MAX", value: newGrs1ScoreMax }),
+    setGrs1ScoreRange: (newGrs1ScoreRange) =>
+      dispatch({ type: "SET_GRS1_SCORE_RANGE", value: newGrs1ScoreRange }),
+    setGrs2ScoreMin: (newGrs2ScoreMin) =>
+      dispatch({ type: "SET_GRS2_SCORE_MIN", value: newGrs2ScoreMin }),
+    setGrs2ScoreMax: (newGrs2ScoreMax) =>
+      dispatch({ type: "SET_GRS2_SCORE_MAX", value: newGrs2ScoreMax }),
+    setGrs2ScoreRange: (newGrs2ScoreRange) =>
+      dispatch({ type: "SET_GRS2_SCORE_RANGE", value: newGrs2ScoreRange }),
+    setAagrsScoreMin: (newAagrsScoreMin) =>
+      dispatch({ type: "SET_AAGRS_SCORE_MIN", value: newAagrsScoreMin }),
+    setAagrsScoreMax: (newAagrsScoreMax) =>
+      dispatch({ type: "SET_AAGRS_SCORE_MAX", value: newAagrsScoreMax }),
+    setAagrsScoreRange: (newAagrsScoreRange) =>
+      dispatch({ type: "SET_AAGRS_SCORE_RANGE", value: newAagrsScoreRange }),
+  };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(FilterGenetic);

--- a/src/component/Explore/component/Result/component/FetchRawData.js
+++ b/src/component/Explore/component/Result/component/FetchRawData.js
@@ -14,6 +14,8 @@ function FetchRawData(props) {
     fetchSampleType();
     fetchElectronMicroscopyImages();
     fetchImmunophenotyping();
+    fetchGenetic();
+    fetchSNP();
 
     //console.log("fetch data was called.");
   }, []);
@@ -158,6 +160,50 @@ function FetchRawData(props) {
       .catch((error) => console.log("Amplify API call error", error));
   }
 
+  // fetch genetic and save as map
+  async function fetchGenetic() {
+    return await API.get("dbapi", "/db/genetic")
+      .then((res) => {
+        // geneticMap is dictionary, key is case_id, value is dictionary of all genetic value pairs.
+        const geneticMap = {};
+        for (var i = 0, tempData, tempKey, tempMap = {}; i < res.length; i++) {
+          tempData = res[i];
+          Object.keys(tempData).map((key) => {
+            if (key === "case_id") {
+              tempKey = tempData[key];
+            } else {
+              tempMap[key] = tempData[key];
+            }
+          });
+          geneticMap[tempKey] = JSON.parse(JSON.stringify(tempMap)); // Deep copy
+        }
+        props.setGeneticMap(geneticMap);
+      })
+      .catch((error) => console.log("Amplify API call error", error));
+  }
+
+  // fetch SNP
+  async function fetchSNP() {
+    return await API.get("dbapi", "/db/SNP")
+      .then((res) => {
+        // SNP is dictionary, key is SNP_id.
+        const SNP = {};
+        for (var i = 0, tempData, tempKey, tempMap = {}; i < res.length; i++) {
+          tempData = res[i];
+          Object.keys(tempData).map((key) => {
+            if (key === "SNP_id") {
+              tempKey = tempData[key];
+            } else {
+              tempMap[key] = tempData[key];
+            }
+          });
+          SNP[tempKey] = JSON.parse(JSON.stringify(tempMap)); // Deep copy
+        }
+        props.setSNP(SNP);
+      })
+      .catch((error) => console.log("Amplify API call error", error));
+  }
+
   return <div></div>;
 }
 
@@ -192,6 +238,9 @@ const mapDispatchToProps = (dispatch) => {
       dispatch({ type: "SET_EMI_MAP", value: newEmiMap }),
     setImmunMap: (newImmunMap) =>
       dispatch({ type: "SET_IMMUN_MAP", value: newImmunMap }),
+    setGeneticMap: (newGeneticMap) =>
+      dispatch({ type: "SET_GENETIC_MAP", value: newGeneticMap }),
+    setSNP: (newSNP) => dispatch({ type: "SET_SNP", value: newSNP }),
   };
 };
 

--- a/src/component/Explore/component/Result/component/Search.js
+++ b/src/component/Explore/component/Result/component/Search.js
@@ -308,14 +308,47 @@ function Search(props) {
           props.highResHLAChecked === false ||
           props.datasetEnable === false
       )
+      // Dataset: immunophenotyping
       .filter(
         (donor) =>
           (props.immunophenotypingChecked === true &&
             donor.case_id in props.immunMap) ||
           props.immunophenotypingChecked === false ||
           props.datasetEnable === false
+      )
+      // Dataset: Whole Exome Sequencing
+      .filter(
+        (donor) =>
+          (props.wholeExomeSequencingAvailable === true &&
+            props.geneticMap[donor.case_id]
+              ?.whole_exome_sequencing_available === 1) ||
+          props.wholeExomeSequencingAvailable === false ||
+          props.datasetEnable === false
+      )
+      // Dataset: SNPs
+      .filter(
+        (donor) =>
+          (props.snpsAvailable === true &&
+            props.geneticMap[donor.case_id]?.GRS1_score) ||
+          props.snpsAvailable === false ||
+          props.datasetEnable === false
+      )
+      // Genetic
+      .filter(
+        (donor) =>
+          (props?.geneticMap[donor.case_id]?.GRS1_score &&
+            props.geneticMap[donor.case_id]?.GRS1_score >= props.grs1ScoreMin &&
+            props.geneticMap[donor.case_id]?.GRS1_score <= props.grs1ScoreMax &&
+            props?.geneticMap[donor.case_id]?.GRS2_score &&
+            props.geneticMap[donor.case_id]?.GRS2_score >= props.grs2ScoreMin &&
+            props.geneticMap[donor.case_id]?.GRS2_score <= props.grs2ScoreMax &&
+            props?.geneticMap[donor.case_id]?.AA_GRS_score &&
+            props.geneticMap[donor.case_id]?.AA_GRS_score >=
+              props.aagrsScoreMin &&
+            props.geneticMap[donor.case_id]?.AA_GRS_score <=
+              props.aagrsScoreMax) ||
+          props.geneticEnable === false
       );
-
   console.log("filtered case data", filteredData);
   console.log("requested case", requestedCase);
   const currTime = new Date();
@@ -333,6 +366,7 @@ function Search(props) {
               <Typography variant="h4">SEARCH RESULT</Typography>
             </Box>
             <Box>
+              {/* Download button */}
               <ExportSpreadsheet
                 csvData={filteredData}
                 fileName={"Download_From_nPOD_" + timeStamp}
@@ -481,12 +515,32 @@ const mapStateToProps = (state) => {
     electronMicroscopyChecked: state.explore.electronMicroscopyChecked,
     highResHLAChecked: state.explore.highResHLAChecked,
     immunophenotypingChecked: state.explore.immunophenotypingChecked,
+    wholeExomeSequencingAvailable: state.explore.wholeExomeSequencingAvailable,
+    wholeExomeSequencingUnavailable:
+      state.explore.wholeExomeSequencingUnavailable,
+    snpsAvailable: state.explore.snpsAvailable,
+    snpsUnavailable: state.explore.snpsUnavailable,
 
     // Electron Microscopy Images
     emiMap: state.explore.emiMap,
 
     // Immunophenotyping
     immunMap: state.explore.immunMap,
+
+    // Genetic
+    geneticEnable: state.explore.geneticEnable,
+    grs1ScoreMin: state.explore.grs1ScoreMin,
+    grs1ScoreMax: state.explore.grs1ScoreMax,
+    grs1ScoreRange: state.explore.grs1ScoreRange,
+    grs2ScoreMin: state.explore.grs2ScoreMin,
+    grs2ScoreMax: state.explore.grs2ScoreMax,
+    grs2ScoreRange: state.explore.grs2ScoreRange,
+    aagrsScoreMin: state.explore.aagrsScoreMin,
+    aagrsScoreMax: state.explore.aagrsScoreMax,
+    aagrsScoreRange: state.explore.aagrsScoreRange,
+
+    // Genetic Map
+    geneticMap: state.explore.geneticMap,
   };
 };
 

--- a/src/component/Landing.js
+++ b/src/component/Landing.js
@@ -269,7 +269,7 @@ function Landing(props) {
           <Grid item>
             <Typography variant={title4} className={classes.centerTitle4}>
               <a href="/support" target="_blank" className={classes.linkText}>
-                SUPPORT
+                TUTORIAL
               </a>
 
               <a href="contact" target="_blank" className={classes.linkText}>


### PR DESCRIPTION
The new tab 'genetic' include all grs related data. 'Percentile' and 'Admixture' displayed as charts.
In the case explore search page, user can download all cases' genetic data through download dropdown menu selection.