### PR TITLE
Update Amylase value range in admin input

### DIFF
--- a/src/component/Admin/component/WriteIn/component/SingleCaseStepper/component/HospitalLabs_step5.js
+++ b/src/component/Admin/component/WriteIn/component/SingleCaseStepper/component/HospitalLabs_step5.js
@@ -143,7 +143,7 @@ export default function HospitalLabs_step5({
     {
       colum: "admission_amylase",
       input: "integerBox",
-      restrict: { type: "int", range: [0, 2500] },
+      restrict: { type: "int", range: [0, 4000] },
       valid: useState(true),
       ops: [],
     },
@@ -164,7 +164,7 @@ export default function HospitalLabs_step5({
     {
       colum: "peak_amylase",
       input: "integerBox",
-      restrict: { type: "int", range: [0, 2500] },
+      restrict: { type: "int", range: [0, 4000] },
       valid: useState(true),
       ops: [],
     },

--- a/src/component/CaseView/component/TabView/component/DonorSummary/component/DonorInformation.js
+++ b/src/component/CaseView/component/TabView/component/DonorSummary/component/DonorInformation.js
@@ -85,7 +85,9 @@ function DonorInformation(props) {
       "BMI Percentile",
       props.currentCase.BMI_percentile === null
         ? "Unavailable"
-        : props.currentCase.BMI_percentile
+        : props.currentCase.BMI_percentile >= 1
+        ? props.currentCase.BMI_percentile
+        : "<1"
     ),
     createData(
       "Cause of Death",


### PR DESCRIPTION
Both admission_amylase and peak_amylase up limit got update to 4000.
Optimize BMI_percentile display on case disaply donor information. Some case has BMI_percentile value less than 1, then display string text "<1" instead of decimal number.