### PR TITLE
Add Generate temp table

### DIFF
--- a/amplify/backend/function/expressLambdaNpod/src/app.js
+++ b/amplify/backend/function/expressLambdaNpod/src/app.js
@@ -60,6 +60,7 @@ var {
   create_dataset_case_identifier,
   create_dataset_example_data_file,
   create_new_rows_into_table,
+  create_temp_clone_table,
 } = require("./service/createDatabase");
 
 var {
@@ -530,6 +531,15 @@ app.post("/db/create_new_rows_into_table", function (req, res) {
   console.log(req.body);
   create_new_rows_into_table(req.body.table_name, req.body.matrix).then(
     (promiseRes) => res.send(promiseRes)
+  );
+});
+
+// create a temp cloned table
+app.post("/db/create_temp_clone_table", function (req, res) {
+  console.log(`creating a temp clone of the table ${req.body.table_name}`);
+  console.log(req.body);
+  create_temp_clone_table(req.body.table_name).then((promiseRes) =>
+    res.send(promiseRes)
   );
 });
 

--- a/amplify/backend/function/expressLambdaNpod/src/service/createDatabase.js
+++ b/amplify/backend/function/expressLambdaNpod/src/service/createDatabase.js
@@ -803,6 +803,31 @@ async function create_new_rows_into_table(table_name, matrix) {
   return await pooledConnection(asyncAction);
 }
 
+// Generate temperal cloned table of a production one
+async function create_temp_clone_table(table_name) {
+  const temp_table_name = table_name + "_temp";
+  const sql1 = `DROP TABLE IF EXISTS ${temp_table_name};`;
+  const sql2 = `CREATE TABLE ${temp_table_name} LIKE ${table_name};`;
+  const sql3 = `INSERT INTO ${temp_table_name} SELECT * FROM ${table_name}`;
+  const sql = sql1 + sql2 + sql3;
+
+  console.log("sql: " + sql);
+
+  const asyncAction = async (newConnection) => {
+    return await new Promise((resolve, reject) => {
+      newConnection.query(sql, (error, result) => {
+        if (error) {
+          reject(error);
+        } else {
+          console.log(`Creating a temp clone of ${table_name} is successful!`);
+          resolve(result);
+        }
+      });
+    });
+  };
+  return await pooledConnection(asyncAction);
+}
+
 module.exports = {
   testPoolForCreate: testPoolForCreate,
   create_case: create_case,
@@ -835,4 +860,5 @@ module.exports = {
   create_dataset_case_identifier: create_dataset_case_identifier,
   create_dataset_example_data_file: create_dataset_example_data_file,
   create_new_rows_into_table: create_new_rows_into_table,
+  create_temp_clone_table: create_temp_clone_table,
 };

--- a/amplify/team-provider-info.json
+++ b/amplify/team-provider-info.json
@@ -16,7 +16,7 @@
       "function": {
         "expressLambdaNpod": {
           "deploymentBucketName": "amplify-amplifynpod-dev-163022-deployment",
-          "s3Key": "amplify-builds/expressLambdaNpod-6a325662796368652f4f-build.zip"
+          "s3Key": "amplify-builds/expressLambdaNpod-6663637a617a32493857-build.zip"
         },
         "AdminQueries0759059b": {
           "deploymentBucketName": "amplify-amplifynpod-dev-163022-deployment",

--- a/src/component/Admin/component/WriteIn/component/ImportData/component/ImportHLADataFile.js
+++ b/src/component/Admin/component/WriteIn/component/ImportData/component/ImportHLADataFile.js
@@ -4,6 +4,7 @@ import { Autocomplete, Alert } from "@material-ui/lab";
 import useRetrieveTableHeaders from "./component/useRetrieveTableHeaders";
 import useRetrieveExisitingPrimaryKeyValues from "./component/useRetrieveExistingPrimaryKeyValues";
 import useDataUpload from "./component/useDataUpload";
+import useCreateTempCloneTable from "./component/useCreateTempCloneTable";
 import Papa from "papaparse";
 import useCheckImportFileFormat from "./component/useCheckImportFileFormat";
 import HeaderMappingTable from "./component/HeaderMappingTable";
@@ -115,6 +116,12 @@ export default function ImportHLADataFile() {
       slices_raw_data: 0,
       immunophenotyping: 0,
     },
+    allCreateClicked: {
+      HLA: 0,
+      RNA: 0,
+      slices_raw_data: 0,
+      immunophenotyping: 0,
+    },
   };
 
   const [needReset, setNeedReset] = useState(initStates.needReset);
@@ -159,6 +166,10 @@ export default function ImportHLADataFile() {
 
   const [allUploadClicked, setAllUploadClicked] = useState(
     initStates.allUploadClicked
+  );
+
+  const [allCreateClicked, setAllCreateClicked] = useState(
+    initStates.allCreateClicked
   );
 
   const handleFileDataImport = (event, targetTable) => {
@@ -233,10 +244,18 @@ export default function ImportHLADataFile() {
     setUploadSuccess(initStates.uploadSuccess);
     setUploadFail(initStates.uploadFail);
     setAllUploadClicked(initStates.allUploadClicked);
+    setAllCreateClicked(initStates.allCreateClicked);
   }
 
   const handleUploadClick = (tableName) => {
     setAllUploadClicked((prevValues) => {
+      return { ...prevValues, [tableName]: prevValues[tableName] + 1 };
+    });
+    setNeedReset(true);
+  };
+
+  const handleCreateClick = (tableName) => {
+    setAllCreateClicked((prevValues) => {
       return { ...prevValues, [tableName]: prevValues[tableName] + 1 };
     });
     setNeedReset(true);
@@ -315,13 +334,37 @@ export default function ImportHLADataFile() {
     setUploadFail
   );
 
-  // slices_raw_data Upload
+  // immunophenotyping Upload
   useDataUpload(
     allTableDataToSend["immunophenotyping"]["checkRes"],
     allUploadClicked["immunophenotyping"],
     allTableDataToSend["immunophenotyping"]["dataToCreate"],
     allTableDataToSend["immunophenotyping"]["dataToUpdate"],
     "immunophenotyping", // tableName
+    setUploadSuccess,
+    setUploadFail
+  );
+
+  // create temp table of HLA
+  useCreateTempCloneTable(
+    allCreateClicked["HLA"],
+    "HLA",
+    setUploadSuccess,
+    setUploadFail
+  );
+
+  // create temp table of slices_raw_data
+  useCreateTempCloneTable(
+    allCreateClicked["slices_raw_data"],
+    "slices_raw_data",
+    setUploadSuccess,
+    setUploadFail
+  );
+
+  // create temp table of immunophenotyping
+  useCreateTempCloneTable(
+    allCreateClicked["immunophenotyping"],
+    "immunophenotyping",
     setUploadSuccess,
     setUploadFail
   );
@@ -437,6 +480,20 @@ export default function ImportHLADataFile() {
         >
           Reset
         </Button>
+
+        <Button
+          variant="contained"
+          component="label"
+          style={{
+            marginTop: 10,
+            marginLeft: 15,
+            color: "white",
+            backgroundColor: "#f99500",
+          }}
+          onClick={(event) => handleCreateClick("HLA")}
+        >
+          Generate Temp Table
+        </Button>
       </Box>
 
       {/* slices_raw_data table import */}
@@ -521,6 +578,20 @@ export default function ImportHLADataFile() {
           onClick={handResetClick}
         >
           Reset
+        </Button>
+
+        <Button
+          variant="contained"
+          component="label"
+          style={{
+            marginTop: 10,
+            marginLeft: 15,
+            color: "white",
+            backgroundColor: "#f99500",
+          }}
+          onClick={(event) => handleCreateClick("slices_raw_data")}
+        >
+          Generate Temp Table
         </Button>
       </Box>
 
@@ -608,6 +679,20 @@ export default function ImportHLADataFile() {
           onClick={handResetClick}
         >
           Reset
+        </Button>
+
+        <Button
+          variant="contained"
+          component="label"
+          style={{
+            marginTop: 10,
+            marginLeft: 15,
+            color: "white",
+            backgroundColor: "#f99500",
+          }}
+          onClick={(event) => handleCreateClick("immunophenotyping")}
+        >
+          Generate Temp Table
         </Button>
       </Box>
     </div>

--- a/src/component/Admin/component/WriteIn/component/ImportData/component/component/useCheckImportFileFormat.js
+++ b/src/component/Admin/component/WriteIn/component/ImportData/component/component/useCheckImportFileFormat.js
@@ -48,14 +48,20 @@ export default function useCheckImportFileFormat(
     existingPrimaryKeyvValuesArr
   ) {
     const existSet = new Set(existingPrimaryKeyvValuesArr);
+
+    // generate a list of raw file primary key values
     const filePrimaryKeyValuesArr = fileData.reduce((tempArr, current) => {
       tempArr.push(current[filePrimaryKey]);
       return tempArr;
     }, []);
+
     const oldDataToUpdate = [];
     const newDataToCreate = [];
+
+    // compare online existing primary key values with file primary key values
+    // then sort out which row is new and which row is existing already
     for (let i = 0; i < filePrimaryKeyValuesArr.length; i++) {
-      let currentFilePrimaryKeyValue = filePrimaryKeyValuesArr[i];
+      let currentFilePrimaryKeyValue = filePrimaryKeyValuesArr[i].toString();
       if (existSet.has(currentFilePrimaryKeyValue)) {
         oldDataToUpdate.push(fileData[i]);
       } else {

--- a/src/component/Admin/component/WriteIn/component/ImportData/component/component/useCreateTempCloneTable.js
+++ b/src/component/Admin/component/WriteIn/component/ImportData/component/component/useCreateTempCloneTable.js
@@ -1,0 +1,49 @@
+import React, { useEffect } from "react";
+import { API } from "aws-amplify";
+
+export default function useCreateTempCloneTable(
+  createClicked,
+  tableName,
+  setUploadSuccess,
+  setUploadFail
+) {
+  useEffect(() => {
+    if (tableName && createClicked > 0) {
+      createTempCloneTable(tableName);
+    }
+  }, [createClicked]);
+
+  async function createTempCloneTable(tableName) {
+    const nowTime = new Date().toLocaleString().replace(",", "");
+
+    return await API.post("dbapi", "/db/create_temp_clone_table", {
+      body: {
+        table_name: tableName,
+      },
+    })
+      .then((res) => {
+        console.log(`Created the temp clone of table ${tableName}`, res);
+        setUploadSuccess((prevValues) => {
+          return {
+            ...prevValues,
+            [tableName]: `Created the temp clone of table ${tableName} successfully!`,
+          };
+        });
+        setUploadFail((prevValues) => {
+          return { ...prevValues, [tableName]: null };
+        });
+      })
+      .catch((error) => {
+        console.log(`New row inserted fail in table ${tableName}`, error);
+        setUploadSuccess((prevValues) => {
+          return { ...prevValues, [tableName]: null };
+        });
+        setUploadFail((prevValues) => {
+          return {
+            ...prevValues,
+            [tableName]: `Creating the temp clone of table ${tableName} failed!`,
+          };
+        });
+      });
+  }
+}


### PR DESCRIPTION
In admin file importing, add a button to generate a new temp clone table from latest table. Then all importing data will be applied to up-to-date table. In the pass, generating temp table always needs developer making changes in mysql directly.

Bug fix: in admin file import, sometime selected file primary key would be converted as numeric value. This could cause comparing online existing primary key value with file primary key value resulting incorrectness.