### PR TITLE
DB table and import file primarykey type not match

### DIFF
--- a/src/component/Admin/component/WriteIn/component/ImportData/component/component/useCheckImportFileFormat.js
+++ b/src/component/Admin/component/WriteIn/component/ImportData/component/component/useCheckImportFileFormat.js
@@ -48,20 +48,34 @@ export default function useCheckImportFileFormat(
     existingPrimaryKeyvValuesArr
   ) {
     const existSet = new Set(existingPrimaryKeyvValuesArr);
-
+    const existPrimaryKeyType =
+      existingPrimaryKeyvValuesArr.length > 0
+        ? typeof existingPrimaryKeyvValuesArr[0]
+        : "string";
     // generate a list of raw file primary key values
     const filePrimaryKeyValuesArr = fileData.reduce((tempArr, current) => {
       tempArr.push(current[filePrimaryKey]);
       return tempArr;
     }, []);
-
+    console.log(
+      "online table existing pirmary key value list",
+      filePrimaryKeyValuesArr
+    );
+    console.log(
+      "existing primary key value list",
+      existingPrimaryKeyvValuesArr
+    );
     const oldDataToUpdate = [];
     const newDataToCreate = [];
 
     // compare online existing primary key values with file primary key values
     // then sort out which row is new and which row is existing already
     for (let i = 0; i < filePrimaryKeyValuesArr.length; i++) {
-      let currentFilePrimaryKeyValue = filePrimaryKeyValuesArr[i].toString();
+      let currentFilePrimaryKeyValue = String(filePrimaryKeyValuesArr[i]);
+      if (existPrimaryKeyType === "number") {
+        currentFilePrimaryKeyValue = Number(filePrimaryKeyValuesArr[i]);
+      }
+
       if (existSet.has(currentFilePrimaryKeyValue)) {
         oldDataToUpdate.push(fileData[i]);
       } else {


### PR DESCRIPTION
DB table primary key type could be number also could be string. When importing file, comparing primary key values needs convert file primary key type to match db table's