### PR TITLE
Adjust admission ABG pH limit for admin input

### DIFF
--- a/src/component/Admin/component/WriteIn/component/SingleCaseStepper/component/HospitalLabs_step5.js
+++ b/src/component/Admin/component/WriteIn/component/SingleCaseStepper/component/HospitalLabs_step5.js
@@ -199,7 +199,7 @@ export default function HospitalLabs_step5({
     {
       colum: "admission_ABG_pH",
       input: "floatBox",
-      restrict: { type: "float", range: [6.7, 7.7] },
+      restrict: { type: "float", range: [6.0, 7.7] },
       valid: useState(true),
       ops: [],
     },


### PR DESCRIPTION
Previous low limitation of input is set to 6.7 and more cases having lower value, so new low limit is set to 6.0