### PR TITLE
[Bug]Fix RNA update issue

### DIFF
--- a/amplify/backend/function/expressLambdaNpod/src/service/updateDatabase.js
+++ b/amplify/backend/function/expressLambdaNpod/src/service/updateDatabase.js
@@ -167,7 +167,7 @@ async function update_RNA(columns) {
       updateStr += "," + key + "=" + columns[key];
     }
   }
-  const sql = `UPDATE RNA SET ${updateStr} WHERE case_id='${columns.case_id}' AND RNA_id='${columns.RNA_id}'`;
+  const sql = `UPDATE RNA SET ${updateStr} WHERE case_id=${columns.case_id} AND RNA_id=${columns.RNA_id}`;
   console.log("sql: ", sql);
   const asyncAction = async (newConnection) => {
     return await new Promise((resolve, reject) => {

--- a/amplify/team-provider-info.json
+++ b/amplify/team-provider-info.json
@@ -16,7 +16,7 @@
       "function": {
         "expressLambdaNpod": {
           "deploymentBucketName": "amplify-amplifynpod-dev-163022-deployment",
-          "s3Key": "amplify-builds/expressLambdaNpod-6663637a617a32493857-build.zip"
+          "s3Key": "amplify-builds/expressLambdaNpod-36347571666765353236-build.zip"
         },
         "AdminQueries0759059b": {
           "deploymentBucketName": "amplify-amplifynpod-dev-163022-deployment",


### PR DESCRIPTION
When the admin updates RNA info on the certain case_id and RNA_id, MySQL reports that conditions syntax having issue. Which is caused by wrapping extra single quote signs. With removing them, the update works as intended.