### PR TITLE
Fix expressjs middle payload issue

### DIFF
--- a/amplify/backend/function/expressLambdaNpod/src/app.js
+++ b/amplify/backend/function/expressLambdaNpod/src/app.js
@@ -85,7 +85,8 @@ var {
 
 // declare a new express app
 var app = express();
-app.use(express.json());
+app.use(express.json({ limit: "10mb" }));
+app.use(express.urlencoded({ extended: true, limit: "10mb" }));
 app.use(awsServerlessExpressMiddleware.eventContext());
 
 // Enable CORS for all methods

--- a/amplify/team-provider-info.json
+++ b/amplify/team-provider-info.json
@@ -16,7 +16,7 @@
       "function": {
         "expressLambdaNpod": {
           "deploymentBucketName": "amplify-amplifynpod-dev-163022-deployment",
-          "s3Key": "amplify-builds/expressLambdaNpod-36347571666765353236-build.zip"
+          "s3Key": "amplify-builds/expressLambdaNpod-2b6c5372595332305865-build.zip"
         },
         "AdminQueries0759059b": {
           "deploymentBucketName": "amplify-amplifynpod-dev-163022-deployment",


### PR DESCRIPTION
The expressjs middleware uses express.json native tool to parse incoming json. The default payload is too little to support a 900-rows file upload. Increased the limit to 10mb then the file upload results no issue.